### PR TITLE
feat(s3): allow anonymous read access for data initialization

### DIFF
--- a/app/entrypoints/initialize_data.py
+++ b/app/entrypoints/initialize_data.py
@@ -58,10 +58,7 @@ def verify_data_integrity(download=False):
     s3_init = None
     if download:
         if not DATA_INIT_S3_CONF['aws_access_key_id'] or not DATA_INIT_S3_CONF['aws_secret_access_key']:
-            logger.warning('S3 credentials not configured. Set ASTRODASH_S3_ACCESS_KEY_ID and '
-                           'ASTRODASH_S3_SECRET_ACCESS_KEY to enable data downloads.')
-            logger.warning('Skipping data download.')
-            return
+            logger.info('S3 credentials not configured. Using anonymous access for read operations.')
         s3_init = ObjectStore(conf=DATA_INIT_S3_CONF)
         if not s3_init.client:
             logger.error('Failed to initialize S3 client. Check ASTRODASH_S3_* environment variables.')

--- a/docs/brainstorms/2026-03-09-anonymous-s3-read-access-brainstorm.md
+++ b/docs/brainstorms/2026-03-09-anonymous-s3-read-access-brainstorm.md
@@ -1,0 +1,28 @@
+---
+title: Anonymous S3 Read Access for Data Initialization
+date: 2026-03-09
+---
+
+# Anonymous S3 Read Access for Data Initialization
+
+## What We're Building
+
+Allow the astrodash data initialization process to download pre-trained models and spectra from the Jetstream S3 bucket without requiring credentials. The bucket supports full anonymous read access (list, stat, download).
+
+## Why This Approach
+
+- The Jetstream bucket at `js2.jetstream-cloud.org:8001` allows anonymous reads
+- The minio Python client already supports anonymous access when empty strings are passed for access_key/secret_key
+- The `ObjectStore` class already passes empty strings by default — no changes needed there
+- The only blocker is an explicit credential check in `initialize_data.py` that returns early when credentials are missing
+- This makes first-time setup much easier — no need to obtain and configure S3 credentials just to run astrodash
+
+## Key Decisions
+
+- **Anonymous for reads, credentials for writes**: When credentials are configured, use them. When absent, proceed with anonymous access for read operations.
+- **Manifest generation also tries anonymous**: `generate_file_manifest()` will attempt anonymous access — it fails gracefully if versioned listing requires authentication.
+- **No changes to ObjectStore**: The class already handles empty credentials correctly.
+
+## Open Questions
+
+- None — the scope is clear and minimal.

--- a/docs/plans/2026-03-09-feat-anonymous-s3-read-access-plan.md
+++ b/docs/plans/2026-03-09-feat-anonymous-s3-read-access-plan.md
@@ -1,0 +1,65 @@
+---
+title: Allow Anonymous S3 Read Access for Data Initialization
+type: feat
+date: 2026-03-09
+---
+
+# Allow Anonymous S3 Read Access for Data Initialization
+
+## Overview
+
+Remove the credential requirement for downloading initialization data from the Jetstream S3 bucket. The bucket supports full anonymous read access (list, stat, download), so credentials should only be required for write operations.
+
+## Problem Statement
+
+Currently `initialize_data.py:60-64` checks for `ASTRODASH_S3_ACCESS_KEY_ID` and `ASTRODASH_S3_SECRET_ACCESS_KEY` and returns early with a warning if either is missing. This means first-time users must obtain and configure S3 credentials before they can run astrodash, even though the bucket is publicly readable.
+
+## Proposed Solution
+
+Remove the early-return credential check in `verify_data_integrity()`. The `ObjectStore` class already handles empty credentials correctly — the minio client treats empty `access_key`/`secret_key` as anonymous access.
+
+## Implementation Steps
+
+### Step 1: Remove credential gate in `initialize_data.py`
+
+In `verify_data_integrity()`, remove lines 60-64:
+
+```python
+# REMOVE THIS BLOCK:
+if not DATA_INIT_S3_CONF['aws_access_key_id'] or not DATA_INIT_S3_CONF['aws_secret_access_key']:
+    logger.warning('S3 credentials not configured. Set ASTRODASH_S3_ACCESS_KEY_ID and '
+                   'ASTRODASH_S3_SECRET_ACCESS_KEY to enable data downloads.')
+    logger.warning('Skipping data download.')
+    return
+```
+
+Replace with an info-level log when credentials are absent:
+
+```python
+if not DATA_INIT_S3_CONF['aws_access_key_id'] or not DATA_INIT_S3_CONF['aws_secret_access_key']:
+    logger.info('S3 credentials not configured. Using anonymous access for read operations.')
+```
+
+Then proceed to initialize the `ObjectStore` and download as normal.
+
+### Step 2: Test
+
+- Start containers **without** S3 credentials configured
+- Verify data downloads complete successfully
+- Start containers **with** S3 credentials configured
+- Verify data downloads still work
+- Test `manifest` command without credentials
+
+## Acceptance Criteria
+
+- [x] Data initialization downloads succeed without S3 credentials
+- [ ] Data initialization downloads still work with S3 credentials
+- [x] Manifest generation attempts anonymous access (may fail gracefully if versioned listing requires auth)
+- [x] Info log message indicates anonymous access when no credentials are present
+- [x] No changes to `ObjectStore` class
+
+## References
+
+- Brainstorm: `docs/brainstorms/2026-03-09-anonymous-s3-read-access-brainstorm.md`
+- `app/entrypoints/initialize_data.py:60-64` — credential gate to remove
+- `app/astrodash/shared/object_store.py:42-48` — minio client already accepts empty credentials


### PR DESCRIPTION
The Jetstream S3 bucket supports anonymous reads. Remove the credential gate that blocked downloads when ASTRODASH_S3_ACCESS_KEY_ID and ASTRODASH_S3_SECRET_ACCESS_KEY are not set. Credentials are still used for write operations when available.

Fixes #  <!-- If your PR relates to an issue mention it here e.g. Issue #34, Issue #56 -->.

## Description of the Change

## Checklist

Please check all that apply to your proposed changes

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [ ] HTML code change
- [ ] Added package dependency
- [ ] Added data
- [ ] Changed django model
- [ ] Documentation change
- [ ] Added or changed TaskRunner

### **Additional context**
<!-- Add any other context or additional information about the problem here.-->
