### PR TITLE
feat: add explorer data files to initialization manifest

### DIFF
--- a/app/entrypoints/astrodash-data.json
+++ b/app/entrypoints/astrodash-data.json
@@ -1,5 +1,29 @@
 [
   {
+    "path": "explorer/dash_twins_embeddings.npy",
+    "version_id": "alzVOKhe8vKa3B-tGx9CMZmA59zwN9J",
+    "etag": "21a135a84bcdb98aa1ffb655d5cbdaca",
+    "size": 15630464
+  },
+  {
+    "path": "explorer/dash_twins_payload.json",
+    "version_id": "mbfiGVcmB9thWuUMjDyqJd1e83l3g.V",
+    "etag": "156bc1fee0dd78b6152554880b02bd1b-5",
+    "size": 76742649
+  },
+  {
+    "path": "explorer/dash_twins_pca.pkl",
+    "version_id": "eseskceHs95C.Q.bGtRO6Q46NsIvp4j",
+    "etag": "b887e8cf4a995b8ddbe93d7c288015e6",
+    "size": 13080
+  },
+  {
+    "path": "explorer/dash_twins_umap.pkl",
+    "version_id": "Sxto7syCmPZc2I62ZzGuuvu9zHoR07w",
+    "etag": "153df66798a7c3e9cb729fd765cf1ae5",
+    "size": 16342825
+  },
+  {
     "path": "pre_trained_models/dash/agnosticZ/model_info.txt",
     "version_id": "w64QjSDtvyNS3jEo7oMKFb3mDNcaYqs",
     "etag": "942281ffb144ae02b3cbfea3153703ac",

--- a/docs/brainstorms/2026-03-14-explorer-data-files-brainstorm.md
+++ b/docs/brainstorms/2026-03-14-explorer-data-files-brainstorm.md
@@ -1,0 +1,46 @@
+# Brainstorm: Add Explorer Data Files to S3 Initialization
+
+**Date:** 2026-03-14
+**Status:** Ready for planning
+
+## What We're Building
+
+Adding four new explorer data files to the existing S3-based data initialization process so they are automatically downloaded into `/mnt/astrodash-data/explorer/` when the container starts.
+
+The files are:
+- `dash_twins_embeddings.npy` (~15 MB) - Embeddings data
+- `dash_twins_payload.json` (~73 MB) - Payload data
+- `dash_twins_pca.pkl` (~13 KB) - PCA model
+- `dash_twins_umap.pkl` (~16 MB) - UMAP model
+
+These support a spectral twins/similarity explorer feature. They are stable and rarely updated, similar to the existing pre-trained models.
+
+## Why This Approach
+
+**Chosen: Add files to the existing manifest (`astrodash-data.json`)**
+
+The project already has a robust S3 download system (`initialize_data.py`) that:
+- Downloads files listed in `astrodash-data.json` from the `astrodash` S3 bucket
+- Verifies integrity via etag checksums
+- Retries failed downloads up to 5 times
+- Skips files that already exist and pass verification
+
+Adding four entries to the manifest requires zero code changes. The existing infrastructure handles everything.
+
+**Rejected alternatives:**
+- **Separate init script:** Over-engineered for 4 stable files; duplicates existing infrastructure.
+- **Django migration:** Anti-pattern; migrations shouldn't make network calls.
+
+## Key Decisions
+
+- **Destination path:** `/mnt/astrodash-data/explorer/` (new subdirectory alongside `pre_trained_models/`, `spectra/`, `user_models/`)
+- **S3 path:** `init/data/explorer/<filename>` (follows existing convention)
+- **Approach:** Upload files to S3, then regenerate the manifest using `python initialize_data.py manifest`
+- **No code changes needed** - only manifest and S3 bucket updates
+
+## Steps
+
+1. Upload the 4 files to S3 bucket `astrodash` under path `init/data/explorer/`
+2. Run `python initialize_data.py manifest` to regenerate `astrodash-data.json` with the new entries
+3. Commit the updated `astrodash-data.json`
+4. On next container start, the files will be automatically downloaded

--- a/docs/plans/2026-03-14-001-feat-add-explorer-data-to-s3-initialization-plan.md
+++ b/docs/plans/2026-03-14-001-feat-add-explorer-data-to-s3-initialization-plan.md
@@ -1,0 +1,114 @@
+---
+title: "feat: Add Explorer Data Files to S3 Initialization"
+type: feat
+status: active
+date: 2026-03-14
+origin: docs/brainstorms/2026-03-14-explorer-data-files-brainstorm.md
+---
+
+# feat: Add Explorer Data Files to S3 Initialization
+
+Add four new explorer data files to the S3 bucket and data manifest so they are automatically downloaded into `/mnt/astrodash-data/explorer/` during container initialization.
+
+## Acceptance Criteria
+
+- [x] Four files uploaded to S3 bucket `astrodash` under `init/data/explorer/`
+- [x] `astrodash-data.json` manifest regenerated and includes the four new entries
+- [ ] Container initialization downloads the files to `/mnt/astrodash-data/explorer/`
+- [ ] Etag verification passes for all four files
+- [ ] Updated `astrodash-data.json` committed to the repository
+
+## Context
+
+A colleague provided four files that support a spectral twins/similarity explorer feature. They need to be available at `/mnt/astrodash-data/explorer/` in the running container (see brainstorm: `docs/brainstorms/2026-03-14-explorer-data-files-brainstorm.md`).
+
+The project already has a robust manifest-based download system (`app/entrypoints/initialize_data.py`) that handles downloading, checksum verification, and retries. No code changes are needed — only S3 uploads and manifest regeneration.
+
+### Files
+
+| File | Size | Description |
+|------|------|-------------|
+| `dash_twins_embeddings.npy` | ~15 MB | Embeddings data |
+| `dash_twins_payload.json` | ~73 MB | Payload data |
+| `dash_twins_pca.pkl` | ~13 KB | PCA model |
+| `dash_twins_umap.pkl` | ~16 MB | UMAP model |
+
+Source location: `/home/skoranda/CAPS/SCiMMA/DASH/new_data/`
+
+### S3 Configuration
+
+- **Endpoint:** `https://js2.jetstream-cloud.org:8001`
+- **Bucket:** `astrodash`
+- **Upload path:** `init/data/explorer/<filename>`
+- **Credentials:** User has write access via `ASTRODASH_S3_ACCESS_KEY_ID` and `ASTRODASH_S3_SECRET_ACCESS_KEY`
+
+## MVP
+
+### Step 1: Upload files to S3
+
+Using the `ObjectStore.put_object()` method or MinIO client directly, upload each file:
+
+```python
+# upload_explorer_data.py (one-time script, not committed)
+import os, sys
+from pathlib import Path
+
+sys.path.append(os.path.join(str(Path(__file__).resolve().parent.parent)))
+from astrodash.shared.object_store import ObjectStore
+
+conf = {
+    'endpoint-url': os.getenv("ASTRODASH_S3_ENDPOINT_URL", 'https://js2.jetstream-cloud.org:8001'),
+    'region-name': os.getenv("ASTRODASH_S3_REGION_NAME", ''),
+    'aws_access_key_id': os.getenv("ASTRODASH_S3_ACCESS_KEY_ID"),
+    'aws_secret_access_key': os.getenv("ASTRODASH_S3_SECRET_ACCESS_KEY"),
+    'bucket': os.getenv("ASTRODASH_S3_BUCKET", 'astrodash'),
+}
+
+s3 = ObjectStore(conf=conf)
+source_dir = '/home/skoranda/CAPS/SCiMMA/DASH/new_data'
+
+for filename in [
+    'dash_twins_embeddings.npy',
+    'dash_twins_payload.json',
+    'dash_twins_pca.pkl',
+    'dash_twins_umap.pkl',
+]:
+    local_path = os.path.join(source_dir, filename)
+    s3_path = f'init/data/explorer/{filename}'
+    print(f'Uploading {filename} to {s3_path}...')
+    s3.put_object(path=s3_path, file_path=local_path)
+    print(f'  Done.')
+
+print('All files uploaded.')
+```
+
+### Step 2: Regenerate manifest
+
+```bash
+cd app
+python entrypoints/initialize_data.py manifest
+```
+
+This reads the S3 bucket contents and writes the updated `astrodash-data.json` with the four new `explorer/` entries.
+
+### Step 3: Verify manifest
+
+Confirm the manifest now contains entries with `"path": "explorer/..."` for all four files.
+
+### Step 4: Commit
+
+```bash
+git add app/entrypoints/astrodash-data.json
+git commit -m "feat: add explorer data files to initialization manifest"
+```
+
+### Step 5: Verify download
+
+On next container start (or by running `python entrypoints/initialize_data.py download`), confirm all four files appear in `/mnt/astrodash-data/explorer/`.
+
+## Sources
+
+- **Origin brainstorm:** [docs/brainstorms/2026-03-14-explorer-data-files-brainstorm.md](docs/brainstorms/2026-03-14-explorer-data-files-brainstorm.md) — decided to use existing manifest approach; rejected separate init script and Django migration alternatives
+- **Initialization script:** `app/entrypoints/initialize_data.py` — download, verify, and manifest commands
+- **S3 client:** `app/astrodash/shared/object_store.py` — `ObjectStore` class with upload/download/checksum methods
+- **Current manifest:** `app/entrypoints/astrodash-data.json` — 810 existing file entries


### PR DESCRIPTION
## Description of the Change

Add four spectral twins/similarity explorer files (embeddings, payload, PCA, UMAP) to astrodash-data.json so they are downloaded to /mnt/astrodash-data/explorer/ during container initialization.

## Checklist

Please check all that apply to your proposed changes

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [ ] HTML code change
- [ ] Added package dependency
- [X] Added data
- [ ] Changed django model
- [X] Documentation change
- [ ] Added or changed TaskRunner

### **Additional context**
<!-- Add any other context or additional information about the problem here.-->
