### PR TITLE
feat: update CI workflow to push images to GitLab Container Registry

### DIFF
--- a/.github/workflows/docker_image_workflow.yml
+++ b/.github/workflows/docker_image_workflow.yml
@@ -5,15 +5,9 @@ on:
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"
       - "dev[0-9]-v[0-9]+.[0-9]+.[0-9]+"
-    paths:
-      - "docker/**"
-      - "env/**"
-      - "app/**"
-      - "run/**"
-      - ".github/**"
 
 jobs:
-  build_test_push:
+  build_push:
     runs-on: ubuntu-latest
     steps:
       - name: Free Disk Space (Ubuntu)
@@ -23,12 +17,14 @@ jobs:
           large-packages: true
           docker-images: false
           swap-storage: true
+
       - name: Checkout
         uses: actions/checkout@v6
-      - name: Prepare
+
+      - name: Prepare tags
         id: prep
         run: |
-          DOCKER_IMAGE=astrodash
+          DOCKER_IMAGE=registry.gitlab.com/ncsa-caps-rse/astrodash-k8s-gitops
           if [[ $GITHUB_REF == refs/tags/v* ]]; then
             VERSION=${GITHUB_REF#refs/tags/}
             TAGS="${DOCKER_IMAGE}:${VERSION},${DOCKER_IMAGE}:latest"
@@ -36,37 +32,21 @@ jobs:
             VERSION=${GITHUB_REF#refs/tags/}
             TAGS="${DOCKER_IMAGE}:${VERSION},${DOCKER_IMAGE}:dev"
           fi
-          echo ::set-output name=tags::${TAGS}
+          echo "tags=${TAGS}" >> $GITHUB_OUTPUT
 
       - name: Set up Docker Buildx
-        id: buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build and export to Docker
-        id: docker_build
+      - name: Log in to GitLab Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: registry.gitlab.com
+          username: ${{ secrets.GITLAB_REGISTRY_USER }}
+          password: ${{ secrets.GITLAB_REGISTRY_TOKEN }}
+
+      - name: Build and push
         uses: docker/build-push-action@v6
         with:
-          builder: ${{ steps.buildx.outputs.name }}
-          context: ./app
-          file: ./app/Dockerfile
-          tags: ${{ steps.prep.outputs.tags }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          push: false
-          load: true
-
-      - name: Run tests
-        run: bash run/astrodashctl ci up
-
-      # - uses: codecov/codecov-action@v4
-      #   with:
-      #     directory: app/
-
-      - name: Push image
-        id: docker_push
-        uses: docker/build-push-action@v6
-        with:
-          builder: ${{ steps.buildx.outputs.name }}
           context: ./app
           file: ./app/Dockerfile
           tags: ${{ steps.prep.outputs.tags }}

--- a/docs/brainstorms/2026-03-15-ci-image-push-to-gitlab-registry-brainstorm.md
+++ b/docs/brainstorms/2026-03-15-ci-image-push-to-gitlab-registry-brainstorm.md
@@ -1,0 +1,38 @@
+# Brainstorm: Update CI to Push Images to GitLab Container Registry
+
+**Date:** 2026-03-15
+**Status:** Ready for planning
+
+## What We're Building
+
+Update the existing GitHub Actions workflow (`docker_image_workflow.yml`) to build the astrodash Docker image and push it to the GitLab Container Registry at `registry.gitlab.com/ncsa-caps-rse/astrodash-k8s-gitops`. This is where the Kubernetes deployment (managed by ArgoCD) pulls images from.
+
+The current workflow is a holdover from the old Blast application. It builds images and attempts to push, but has no registry login step and uses bare image names with no registry prefix — so pushes fail silently.
+
+## Why This Approach
+
+**Chosen: Update the existing GitHub Actions workflow to push to GitLab registry**
+
+The app source code lives in GitHub, so GitHub Actions is the natural CI system. The GitOps repo is in GitLab, and GitLab Container Registry is already configured as the image source in the Helm chart. The workflow just needs:
+1. A `docker/login-action` step targeting `registry.gitlab.com`
+2. Updated image tags with the full registry prefix
+3. GitLab deploy token credentials stored as GitHub Actions secrets
+
+**Rejected alternatives:**
+- **Migrate CI to GitLab CI:** Would require mirroring the source repo to GitLab. Unnecessary complexity.
+- **Use Docker Hub:** The Kubernetes imagePullSecret and Helm chart are already configured for GitLab registry.
+
+## Key Decisions
+
+- **Trigger:** Keep tag-only triggers (`v*` and `dev*` tags), no change
+- **Registry:** `registry.gitlab.com/ncsa-caps-rse/astrodash-k8s-gitops`
+- **Auth:** Reuse existing deploy token (`gitlab+deploy-token-12722131`), stored as GitHub Actions secrets `GITLAB_REGISTRY_USER` and `GITLAB_REGISTRY_TOKEN`
+- **Tag strategy:** Keep current — `v*` tags produce `:version` + `:latest`, `dev*` tags produce `:version` + `:dev`
+- **Tests:** Skip for now (the `astrodashctl ci up` test step will be removed temporarily)
+- **Auto-deploy:** No. Image tag in the GitOps repo `values.yaml` will be updated manually
+- **Paths filter:** Remove or update the `paths:` filter since it may prevent the workflow from running on tag pushes
+
+## Resolved Questions
+
+- **GitHub secrets needed:** `GITLAB_REGISTRY_USER` (set to `gitlab+deploy-token-12722131`) and `GITLAB_REGISTRY_TOKEN` (set to the deploy token value). These must be added to the GitHub repo's Settings > Secrets.
+- **Deploy token permissions:** The existing deploy token must have `read_registry` and `write_registry` scopes. Verify this in GitLab project settings.

--- a/docs/plans/2026-03-15-002-feat-ci-push-to-gitlab-registry-plan.md
+++ b/docs/plans/2026-03-15-002-feat-ci-push-to-gitlab-registry-plan.md
@@ -1,0 +1,101 @@
+---
+title: "feat: Update CI to Push Images to GitLab Container Registry"
+type: feat
+status: active
+date: 2026-03-15
+origin: docs/brainstorms/2026-03-15-ci-image-push-to-gitlab-registry-brainstorm.md
+---
+
+# feat: Update CI to Push Images to GitLab Container Registry
+
+Update `docker_image_workflow.yml` to build and push Docker images to `registry.gitlab.com/ncsa-caps-rse/astrodash-k8s-gitops`.
+
+## Acceptance Criteria
+
+- [x] Workflow logs in to GitLab Container Registry using deploy token
+- [x] Image tagged with full registry path (`registry.gitlab.com/ncsa-caps-rse/astrodash-k8s-gitops:tag`)
+- [x] `v*` tags produce `:version` + `:latest`; `dev*` tags produce `:version` + `:dev`
+- [ ] GitHub secrets `GITLAB_REGISTRY_USER` and `GITLAB_REGISTRY_TOKEN` configured in repo settings
+- [ ] Workflow pushes successfully on tag creation
+
+## MVP
+
+### .github/workflows/docker_image_workflow.yml
+
+Changes needed:
+1. Add `docker/login-action` step before the push step
+2. Update `DOCKER_IMAGE` to include full registry path
+3. Remove the test step (temporarily)
+4. Remove or fix the `paths:` filter (it can prevent tag-triggered runs)
+5. Use `set-output` replacement (`$GITHUB_OUTPUT`) since `::set-output` is deprecated
+
+```yaml
+name: Publish Docker image
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+      - "dev[0-9]-v[0-9]+.[0-9]+.[0-9]+"
+
+jobs:
+  build_push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          large-packages: true
+          docker-images: false
+          swap-storage: true
+
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Prepare tags
+        id: prep
+        run: |
+          DOCKER_IMAGE=registry.gitlab.com/ncsa-caps-rse/astrodash-k8s-gitops
+          if [[ $GITHUB_REF == refs/tags/v* ]]; then
+            VERSION=${GITHUB_REF#refs/tags/}
+            TAGS="${DOCKER_IMAGE}:${VERSION},${DOCKER_IMAGE}:latest"
+          elif [[ $GITHUB_REF == refs/tags/dev* ]]; then
+            VERSION=${GITHUB_REF#refs/tags/}
+            TAGS="${DOCKER_IMAGE}:${VERSION},${DOCKER_IMAGE}:dev"
+          fi
+          echo "tags=${TAGS}" >> $GITHUB_OUTPUT
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitLab Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: registry.gitlab.com
+          username: ${{ secrets.GITLAB_REGISTRY_USER }}
+          password: ${{ secrets.GITLAB_REGISTRY_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: ./app
+          file: ./app/Dockerfile
+          tags: ${{ steps.prep.outputs.tags }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64
+          push: true
+```
+
+### GitHub repo settings
+
+Add these secrets in the GitHub repo Settings > Secrets and variables > Actions:
+- `GITLAB_REGISTRY_USER`: `gitlab+deploy-token-12722131`
+- `GITLAB_REGISTRY_TOKEN`: the deploy token value
+
+## Sources
+
+- **Origin brainstorm:** [docs/brainstorms/2026-03-15-ci-image-push-to-gitlab-registry-brainstorm.md](docs/brainstorms/2026-03-15-ci-image-push-to-gitlab-registry-brainstorm.md)
+- **Current workflow:** `.github/workflows/docker_image_workflow.yml`
+- **GitOps repo:** `gitlab.com/ncsa-caps-rse/astrodash-k8s-gitops`


### PR DESCRIPTION

Fixes #  <!-- If your PR relates to an issue mention it here e.g. Issue #34, Issue #56 -->.

## Description of the Change

- Add docker/login-action for registry.gitlab.com authentication
- Update image tags to include full GitLab registry path
- Replace deprecated ::set-output with $GITHUB_OUTPUT
- Remove paths filter that could prevent tag-triggered runs
- Remove test step temporarily (to be restored later)
- Consolidate to single build+push step

Requires GitHub secrets GITLAB_REGISTRY_USER and GITLAB_REGISTRY_TOKEN to be configured in the repository settings.


## Checklist

Please check all that apply to your proposed changes

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [ ] HTML code change
- [ ] Added package dependency
- [ ] Added data
- [ ] Changed django model
- [ ] Documentation change
- [ ] Added or changed TaskRunner

### **Additional context**
<!-- Add any other context or additional information about the problem here.-->
