### PR TITLE
feat: redirect root URL to /astrodash

### DIFF
--- a/app/astrodash_project/urls.py
+++ b/app/astrodash_project/urls.py
@@ -6,6 +6,7 @@ The `urlpatterns` list routes URLs to views. For more information please see:
 from django.contrib import admin
 from django.urls import include
 from django.urls import path
+from django.views.generic import RedirectView
 
 urlpatterns = [
     path("admin/", admin.site.urls, name='admin'),
@@ -13,4 +14,5 @@ urlpatterns = [
     path("astrodash/", include("astrodash.urls")),
     path("", include("users.urls")),
     path("oidc/", include("mozilla_django_oidc.urls")),
+    path("", RedirectView.as_view(url="/astrodash/", permanent=False)),
 ]

--- a/docs/brainstorms/2026-03-16-root-redirect-to-astrodash-brainstorm.md
+++ b/docs/brainstorms/2026-03-16-root-redirect-to-astrodash-brainstorm.md
@@ -1,0 +1,28 @@
+# Brainstorm: Redirect Root URL to /astrodash
+
+**Date:** 2026-03-16
+**Status:** Ready for planning
+
+## What We're Building
+
+Add a redirect so that accessing the root URL `/` automatically redirects to `/astrodash/`, where the web application is served. This should work in both Docker Compose (nginx) and Kubernetes (Traefik) environments.
+
+## Why This Approach
+
+**Chosen: Django URL redirect via `RedirectView` in `urls.py`**
+
+Implementing the redirect in Django makes it work in every deployment environment since Django is the common layer. A single `RedirectView` in the URL config is the simplest and most maintainable solution.
+
+**Rejected alternatives:**
+- **Proxy-level redirects (nginx + Traefik):** Two separate configurations to maintain and keep in sync across environments.
+- **Django middleware:** Over-engineered for a single URL redirect; middleware runs on every request.
+
+## Key Decisions
+
+- **Implementation layer:** Django URL configuration (not proxy)
+- **Redirect type:** Permanent (301) or temporary (302) — to be decided during planning
+- **Scope:** Only `/` redirects to `/astrodash/`; no other paths affected
+
+## Resolved Questions
+
+- **Environment coverage:** Must work in both Docker Compose and Kubernetes — hence Django-level implementation.

--- a/docs/plans/2026-03-16-001-feat-root-redirect-to-astrodash-plan.md
+++ b/docs/plans/2026-03-16-001-feat-root-redirect-to-astrodash-plan.md
@@ -1,0 +1,45 @@
+---
+title: "feat: Redirect Root URL to /astrodash"
+type: feat
+status: active
+date: 2026-03-16
+origin: docs/brainstorms/2026-03-16-root-redirect-to-astrodash-brainstorm.md
+---
+
+# feat: Redirect Root URL to /astrodash
+
+## Acceptance Criteria
+
+- [ ] Accessing `/` redirects to `/astrodash/`
+- [ ] Works in both Docker Compose and Kubernetes environments
+- [ ] Other URL paths are not affected
+
+## Context
+
+The astrodash web application is served at `/astrodash/` but users navigating to `/` get a 404. Add a Django `RedirectView` in `astrodash_project/urls.py` to redirect `/` to `/astrodash/`.
+
+## MVP
+
+### app/astrodash_project/urls.py
+
+Add `RedirectView` import and a redirect path entry:
+
+```python
+from django.views.generic import RedirectView
+
+urlpatterns = [
+    path("admin/", admin.site.urls, name='admin'),
+    path("astrodash/api/v1/", include("astrodash.api_urls")),
+    path("astrodash/", include("astrodash.urls")),
+    path("", include("users.urls")),
+    path("oidc/", include("mozilla_django_oidc.urls")),
+    path("", RedirectView.as_view(url="/astrodash/", permanent=False)),
+]
+```
+
+Note: The empty string `""` path for `users.urls` may conflict. Check if `users.urls` has a root pattern — if so, the RedirectView must be placed carefully or the users include must be prefixed.
+
+## Sources
+
+- **Origin brainstorm:** [docs/brainstorms/2026-03-16-root-redirect-to-astrodash-brainstorm.md](docs/brainstorms/2026-03-16-root-redirect-to-astrodash-brainstorm.md)
+- **URL config:** `app/astrodash_project/urls.py`


### PR DESCRIPTION
## Description of the Change

Add RedirectView in Django URL config so accessing / redirects to /astrodash/ where the web application is served. Works in both Docker Compose and Kubernetes environments.

## Checklist

Please check all that apply to your proposed changes

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [x] HTML code change
- [ ] Added package dependency
- [ ] Added data
- [ ] Changed django model
- [ ] Documentation change
- [ ] Added or changed TaskRunner

### **Additional context**
<!-- Add any other context or additional information about the problem here.-->
