### PR TITLE
feat: reduce Docker image size from 9GB to 1.8GB

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,15 +1,30 @@
-FROM python:3.11.13 AS deps
+FROM python:3.11-slim AS deps
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    gcc \
+    g++ \
+    libpq-dev \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN pip install --upgrade pip
+
+# Install CPU-only PyTorch first
+RUN pip install --no-cache-dir \
+    torch==2.9.0+cpu \
+    torchvision==0.24.0+cpu \
+    --index-url https://download.pytorch.org/whl/cpu
+
+# Install remaining dependencies
 COPY ./requirements.txt /requirements.txt
 RUN pip install -r /requirements.txt --no-cache-dir
 
-FROM python:3.11.13
+FROM python:3.11-slim
 ENV PYTHONUNBUFFERED=1
 
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive && apt-get install -y --no-install-recommends \
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     jq \
-    && rm -rf /var/lib/apt/list/*
+    libpq5 \
+    && rm -rf /var/lib/apt/lists/*
 
 COPY --from=deps /usr/local/lib/python3.11/site-packages/ /usr/local/lib/python3.11/site-packages/
 COPY --from=deps /usr/local/bin/ /usr/local/bin/

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -25,8 +25,7 @@ pydantic==2.5.0
 pydantic-settings==2.1.0
 psycopg2-binary==2.9.11
 redis==7.0.1
-torch==2.9.0
-torchvision==0.24.0
+# torch and torchvision installed separately in Dockerfile with CPU-only index
 umap-learn>=0.5.0
 watchdog==6.0.0
 whitenoise==6.9.0

--- a/docs/brainstorms/2026-03-16-reduce-docker-image-size-brainstorm.md
+++ b/docs/brainstorms/2026-03-16-reduce-docker-image-size-brainstorm.md
@@ -1,0 +1,35 @@
+# Brainstorm: Reduce Docker Image Size
+
+**Date:** 2026-03-16
+**Status:** Ready for planning
+
+## What We're Building
+
+Reduce the astrodash Docker image from ~9GB to ~3GB without removing any functionality. The large image causes disk pressure on Kubernetes worker nodes and slow pull times.
+
+## Why This Approach
+
+**Chosen: CPU-only PyTorch + python:3.11-slim base image**
+
+The two biggest size contributors are:
+1. **PyTorch with CUDA** (~2.5GB) — the app auto-detects GPU availability and falls back to CPU. The Jetstream2 cluster has no GPUs, so CUDA libraries are dead weight.
+2. **Full python:3.11 base image** (~1GB) — includes build tools, compilers, and documentation not needed at runtime.
+
+Switching to CPU-only PyTorch variants and the slim base image saves ~5-6GB with zero functionality loss.
+
+**Rejected alternatives:**
+- **Alpine base:** musl libc breaks scientific Python packages (numpy, scipy, torch). Not practical.
+- **Distroless:** Complex to get right with native extensions. Fragile build process.
+
+## Key Decisions
+
+- **Base image:** `python:3.11-slim` (both build and runtime stages)
+- **PyTorch:** Install CPU-only variant via `--index-url https://download.pytorch.org/whl/cpu`
+- **torchvision:** Same CPU-only index
+- **System deps:** The slim image may need `apt-get install` for some build dependencies in the deps stage (gcc, etc.) but the runtime stage stays minimal
+- **No functionality removed:** All features preserved, GPU auto-detection still works (just won't find a GPU)
+
+## Resolved Questions
+
+- **GPU usage:** Code uses `torch.device('cuda' if torch.cuda.is_available() else 'cpu')` — GPU-optional. CPU-only is fine.
+- **Expected size:** ~9GB → ~3GB (estimated)

--- a/docs/plans/2026-03-16-002-feat-reduce-docker-image-size-plan.md
+++ b/docs/plans/2026-03-16-002-feat-reduce-docker-image-size-plan.md
@@ -1,0 +1,34 @@
+---
+title: "feat: Reduce Docker Image Size"
+type: feat
+status: active
+date: 2026-03-16
+origin: docs/brainstorms/2026-03-16-reduce-docker-image-size-brainstorm.md
+---
+
+# feat: Reduce Docker Image Size
+
+## Acceptance Criteria
+
+- [x] Image size reduced from ~9GB to ~3GB or less (achieved 1.82GB — 80% reduction)
+- [ ] All application functionality preserved
+- [ ] CPU-only PyTorch inference works correctly
+- [x] Image builds successfully
+
+## MVP
+
+### app/Dockerfile
+
+- Switch both stages to `python:3.11-slim`
+- Install build dependencies (gcc, etc.) in the deps stage only
+- Install torch and torchvision from CPU-only index
+
+### app/requirements.txt
+
+- Remove `torch` and `torchvision` from main requirements (install separately in Dockerfile with CPU-only index)
+
+## Sources
+
+- **Origin brainstorm:** [docs/brainstorms/2026-03-16-reduce-docker-image-size-brainstorm.md](docs/brainstorms/2026-03-16-reduce-docker-image-size-brainstorm.md)
+- **Dockerfile:** `app/Dockerfile`
+- **Requirements:** `app/requirements.txt`


### PR DESCRIPTION
## Description of the Change

- Switch base image from python:3.11 to python:3.11-slim
- Install PyTorch and torchvision as CPU-only variants via --index-url https://download.pytorch.org/whl/cpu
- Add build dependencies (gcc, g++, libpq-dev) to deps stage only
- Add libpq5 to runtime stage for psycopg2

No functionality removed. GPU detection still works but falls back to CPU (no GPUs on Jetstream2 cluster).

## Checklist

Please check all that apply to your proposed changes

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [ ] HTML code change
- [x] Added package dependency
- [ ] Added data
- [ ] Changed django model
- [ ] Documentation change
- [ ] Added or changed TaskRunner

### **Additional context**
<!-- Add any other context or additional information about the problem here.-->
