### PR TITLE
fix: update footer contact email and institution link

### DIFF
--- a/app/astrodash/templates/astrodash/base_site.html
+++ b/app/astrodash/templates/astrodash/base_site.html
@@ -176,7 +176,7 @@
         <span style="font-size: 1.2rem; color: #c9c9c9">//</span> <a href="https://github.com/scimma/astrodash/issues"><i class="bi-github" role="img" aria-label="GitHub"></i> Report bugs/issues</a>
         <span style="margin-left:2px">
           <span class="text-muted"><span style="font-size: 1.2rem; color: #c9c9c9">//</span>
-            <a href="https://www.ifa.hawaii.edu/">University of Hawai&#699;i IfA</a> /
+            <a href="https://www.space.mit.edu/">MIT Kavli</a> /
             <a href="https://ncsa.illinois.edu/">UIUC:NCSA</a>:<a href="https://caps.ncsa.illinois.edu/">CAPS</a> /
             <a href="https://www.scimma.org/">SCIMMA</a>
           </span>

--- a/app/astrodash_project/settings.py
+++ b/app/astrodash_project/settings.py
@@ -226,7 +226,7 @@ LOGIN_REDIRECT_URL = "/astrodash/"
 LOGOUT_REDIRECT_URL = os.environ.get('OIDC_OP_LOGOUT_ENDPOINT', '/')
 
 # Email for support requests
-SUPPORT_EMAIL = os.getenv('SUPPORT_EMAIL', "devnull@example.com")
+SUPPORT_EMAIL = os.getenv('SUPPORT_EMAIL', "support@scimma.org")
 
 # ALLOW_LOGOUT_GET_METHOD tells mozilla-django-oidc that the front end can logout with a GET
 # which allows the front end to use location.href to /auth/logout to logout.


### PR DESCRIPTION
## Description of the Change

- Change support email default from devnull@example.com to support@scimma.org
- Replace University of Hawai'i IfA link with MIT Kavli (https://www.space.mit.edu/)

## Checklist

Please check all that apply to your proposed changes

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [x] HTML code change
- [ ] Added package dependency
- [ ] Added data
- [ ] Changed django model
- [ ] Documentation change
- [ ] Added or changed TaskRunner

### **Additional context**
<!-- Add any other context or additional information about the problem here.-->
