### PR TITLE
feat: add SCiMMA logo to footer and NSF acknowledgement

### DIFF
--- a/app/astrodash/static/astrodash/images/scimma-logo.svg
+++ b/app/astrodash/static/astrodash/images/scimma-logo.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 180 180">
+  <g stroke="#00B68C" stroke-width="12.0" fill="none" stroke-linecap="round">
+    <path d="M 26.010,59.760 A 84.2,84.2 0 0 1 136.366,56.494"/>
+    <circle cx="127.9" cy="76.8" r="22.0"/>
+    <path d="M 40.485,119.443 A 85.42,85.42 0 0 0 151.120,116.770"/>
+    <circle cx="49.1" cy="99.2" r="22.0"/>
+  </g>
+</svg>

--- a/app/astrodash/templates/astrodash/base_site.html
+++ b/app/astrodash/templates/astrodash/base_site.html
@@ -178,11 +178,14 @@
           <span class="text-muted"><span style="font-size: 1.2rem; color: #c9c9c9">//</span>
             <a href="https://www.space.mit.edu/">MIT Kavli</a> /
             <a href="https://ncsa.illinois.edu/">UIUC:NCSA</a>:<a href="https://caps.ncsa.illinois.edu/">CAPS</a> /
-            <a href="https://www.scimma.org/">SCIMMA</a>
+            <a href="https://www.scimma.org/"><img src="{% static 'astrodash/images/scimma-logo.svg' %}" alt="SCiMMA" style="height: 16px; vertical-align: text-bottom; margin-right: 3px;">SCIMMA</a>
           </span>
           <span class="text-muted"><span style="font-size: 1.2rem; color: #c9c9c9">//</span> <a href="https://github.com/scimma/astrodash/releases/tag/{% app_version "v" %}">{% app_version "v" %}</a></span>
         </span>
       </span>
+      <div class="text-muted" style="font-size: 0.75rem; margin-top: 6px;">
+        This project is supported by National Science Foundation grants <a href="https://www.nsf.gov/awardsearch/showAward?AWD_ID=1841625">OAC-1841625</a>, <a href="https://www.nsf.gov/awardsearch/showAward?AWD_ID=1934752">OAC-1934752</a>, <a href="https://www.nsf.gov/awardsearch/showAward?AWD_ID=2311355&HistoricalAwards=false">OAC-2311355</a>, <a href="https://www.nsf.gov/awardsearch/showAward?AWD_ID=2432428">AST-2432428</a>. Any opinions, findings, conclusions or recommendations expressed in this material are those of the developers and do not necessarily reflect the views of the National Science Foundation.
+      </div>
     </div>
   </footer>
 


### PR DESCRIPTION
## Description of the Change

- Add inline SCiMMA logo (SVG) next to the SCIMMA link in the footer
- Add NSF grant acknowledgement as a second line in smaller text


## Checklist

Please check all that apply to your proposed changes

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [x] HTML code change
- [ ] Added package dependency
- [ ] Added data
- [ ] Changed django model
- [ ] Documentation change
- [ ] Added or changed TaskRunner

### **Additional context**
<!-- Add any other context or additional information about the problem here.-->
