### PR TITLE
fix: add compatibility shim for UMAPWrapper pickle deserialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -151,4 +151,3 @@ quiverMaps/
 app/astrodash/explorer/dash_twinsfromspace.html
 astrodash-logs/
 app/astrodash/tests/
-app/astrodash/explorer/

--- a/app/astrodash/explorer/umap_wrapper.py
+++ b/app/astrodash/explorer/umap_wrapper.py
@@ -1,0 +1,15 @@
+"""
+Compatibility shim for unpickling dash_twins_umap.pkl.
+
+The UMAP pickle was serialized with a UMAPWrapper class from
+astrodash.explorer.umap_wrapper. This module provides that class
+so pickle.load() can deserialize the file. The wrapper delegates
+transform() to the inner umap.UMAP reducer.
+"""
+
+
+class UMAPWrapper:
+    """Thin wrapper around umap.UMAP used during pickle serialization."""
+
+    def transform(self, X):
+        return self.reducer.transform(X)


### PR DESCRIPTION
The dash_twins_umap.pkl was serialized with a UMAPWrapper class from astrodash.explorer.umap_wrapper which doesn't exist in the current codebase. Add a minimal shim module so pickle.load() can deserialize the file. The wrapper delegates transform() to the inner umap.UMAP.



## Additional context
<!-- Add any other context or additional information about the problem here.-->

## Fixes #  <!-- If your PR relates to an issue mention it here e.g. Issue #34, Issue #56 -->.

## Checklist

Please check all that apply to your proposed changes

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [ ] HTML code change
- [ ] Added package dependency
- [ ] Added data
- [ ] Changed django model
- [ ] Documentation change
- [ ] Added or changed TaskRunner
