### PR TITLE
Adjust spacing for legend and add loading note

### DIFF
--- a/app/astrodash/templates/astrodash/explorer/dash_twins.html
+++ b/app/astrodash/templates/astrodash/explorer/dash_twins.html
@@ -77,6 +77,7 @@
   <div class="muted" style="margin-bottom: 10px;">
     Twins are nearest neighbors in the original embedding space (cosine similarity).
     Projection toggle only changes the 2D display.
+    Please note: the explorer may take a few seconds to load.
   </div>
 
   <div class="banner">
@@ -351,13 +352,24 @@ Plotly.newPlot("plot", [...traces, twinsTrace, targetTrace], layout, {responsive
 
 function specLayout() {
   return {
-    margin: {l: 70, r: 20, t: 30, b: 80},
-    xaxis: {title: "Wavelength [Å]", automargin: true, title_standoff: 10},
-    yaxis: {title: "Flux",            automargin: true, title_standoff: 10},
+    margin: {l: 70, r: 20, t: 45, b: 150},
+    title: {text: "", x: 0.5},
+    xaxis: {
+      title: "Wavelength [Å]",
+      automargin: true,
+      title_standoff: 28
+    },
+    yaxis: {
+      title: "Flux",
+      automargin: true,
+      title_standoff: 10
+    },
     legend: {
       orientation: "h",
-      x: 0.0, xanchor: "left",
-      y: -0.25, yanchor: "top",
+      x: 0,
+      xanchor: "left",
+      y: -0.50,
+      yanchor: "top",
       font: {size: 10}
     }
   };


### PR DESCRIPTION

## Additional context
This PR adjusts the spacing in the twins spectra plot so the wavelength axis label has more separation from the horizontal legend, further adjustment may still be needed, but this should allow for no overlaying between legend and axis labels on 90% zoom in the browser. Added a note that the explorer may take a few seconds to load.

## Fixes #
## Checklist

- [x] HTML code change
- [ ] Added package dependency
- [ ] Added data
- [ ] Changed django model
- [ ] Documentation change
- [ ] Added or changed TaskRunner
