### PR TITLE
Issue #37,  #27, #28, and #32

### DIFF
--- a/app/astrodash/infrastructure/storage/file_spectrum_repository.py
+++ b/app/astrodash/infrastructure/storage/file_spectrum_repository.py
@@ -167,8 +167,9 @@ class FileSpectrumRepository(SpectrumRepository):
             return None
 
     def _read_text_file(self, file_obj, filename: str) -> Optional[Spectrum]:
-        """Read .dat or .txt file: two-column wavelength/flux, filter 4000–9000 Å."""
+        """Read .dat or .txt file: two-column wavelength/flux, filter 4000-9000 Å."""
         try:
+            import re
             if hasattr(file_obj, 'read'):
                 file_obj.seek(0)
                 content = file_obj.read()
@@ -184,7 +185,8 @@ class FileSpectrumRepository(SpectrumRepository):
                 line = line.strip()
                 if not line or line.startswith('#'):
                     continue
-                parts = line.split()
+                # Support both space/tab-separated and comma-separated rows in .txt/.dat files.
+                parts = re.split(r'[\s,]+', line)
                 if len(parts) < 2:
                     continue
                 try:

--- a/app/astrodash/templates/astrodash/base.html
+++ b/app/astrodash/templates/astrodash/base.html
@@ -4,6 +4,21 @@
 {% block title %}Astrodash{% endblock %}
 
 {% block body %}
+{% if messages %}
+<div id="astrodash-messages" style="position: fixed; top: 84px; left: 50%; transform: translateX(-50%); z-index: 2000; width: min(860px, calc(100% - 32px));">
+    {% for message in messages %}
+    <div
+        class="alert {% if 'error' in message.tags %}alert-danger{% elif 'warning' in message.tags %}alert-warning{% elif 'success' in message.tags %}alert-success{% else %}alert-info{% endif %} alert-dismissible fade show mb-2"
+        role="alert"
+    >
+        {{ message }}
+        <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+            <span aria-hidden="true">&times;</span>
+        </button>
+    </div>
+    {% endfor %}
+</div>
+{% endif %}
 <div class="astrodash-wrapper">
     <!-- Astrodash Sub-navigation or Header could go here if needed -->
     {% block content %}
@@ -17,5 +32,19 @@
 <script src="https://cdn.bokeh.org/bokeh/release/bokeh-widgets-3.3.0.min.js"></script>
 <script src="https://cdn.bokeh.org/bokeh/release/bokeh-tables-3.3.0.min.js"></script>
 <script src="https://cdn.bokeh.org/bokeh/release/bokeh-api-3.3.0.min.js"></script>
+<script>
+document.addEventListener("DOMContentLoaded", function() {
+    var alerts = document.querySelectorAll("#astrodash-messages .alert");
+    alerts.forEach(function(alertEl) {
+        setTimeout(function() {
+            if (window.jQuery && window.jQuery.fn && window.jQuery.fn.alert) {
+                window.jQuery(alertEl).alert("close");
+            } else if (alertEl && alertEl.parentNode) {
+                alertEl.parentNode.removeChild(alertEl);
+            }
+        }, 6000);
+    });
+});
+</script>
 {% block extra_scripts %}{% endblock %}
 {% endblock %}

--- a/app/astrodash/templates/astrodash/classify.html
+++ b/app/astrodash/templates/astrodash/classify.html
@@ -68,6 +68,11 @@
 
                         <div class="form-group">
                             {{ form.file|as_crispy_field }}
+                            {% if persisted_file_name %}
+                            <small class="form-text text-muted">
+                                Active file: <strong>{{ persisted_file_name }}</strong>
+                            </small>
+                            {% endif %}
                         </div>
 
                         <hr>

--- a/app/astrodash/templates/astrodash/classify.html
+++ b/app/astrodash/templates/astrodash/classify.html
@@ -235,7 +235,7 @@
                 <h4 class="alert-heading">Welcome!</h4>
                 <p>Use the form on the left to upload a spectrum file and start classification.</p>
                 <hr>
-                <p class="mb-0">Supported formats: single-column or two-column text files.</p>
+                <p class="mb-0">Supported formats: two-column (wavelength, flux) text files and .csv, .fits, .lnw, .flm, .spec, .dat, and .ascii file extensions.</p>
             </div>
             {% endif %}
         </div>

--- a/app/astrodash/templates/astrodash/classify.html
+++ b/app/astrodash/templates/astrodash/classify.html
@@ -200,7 +200,7 @@
                 </div>
                 <div class="card-body">
                     <p><strong>Model Used:</strong> {{ model_type }}</p>
-                    <table class="table table-striped table-hover">
+                    <table class="table table-striped table-hover" id="best-matches-table">
                         <thead>
                             <tr>
                                 <th>SN Type</th>
@@ -212,7 +212,7 @@
                         </thead>
                         <tbody>
                             {% for match in results.best_matches %}
-                            <tr>
+                            <tr class="best-match-row" data-sn-type="{{ match.type }}" data-age="{{ match.age }}">
                                 <td><span class="badge badge-info">{{ match.type }}</span></td>
                                 <td>{{ match.age }}</td>
                                 <td>{{ match.formatted_probability }}</td>
@@ -260,7 +260,8 @@
 (function() {
     var plotConfig = {
         apiBase: "{{ plot_api_base|escapejs }}",
-        classifyUrl: "{{ request.path|escapejs }}"
+        classifyUrl: "{{ request.path|escapejs }}",
+        analysisOptionsUrl: "{% url 'astrodash_api:analysis_options' %}"
     };
     var twinsBaseUrl = "{% url 'astrodash:dash_twins' %}";
     var initialElements = [];
@@ -277,7 +278,7 @@
     function templateKeyDisplay(snType, age) { return snType + " " + age; }
 
     function applyOverlays() {
-        var params = [];
+        var params = ["overlay_apply=1"];
         selectedElements.forEach(function(el) {
             params.push("overlay_elements=" + encodeURIComponent(el));
         });
@@ -385,10 +386,37 @@
         }
         updateVisibleTemplatesList();
 
+        function applyOverlaysWithPreviewTemplate(previewKey) {
+            var params = ["overlay_apply=1"];
+            selectedElements.forEach(function(el) {
+                params.push("overlay_elements=" + encodeURIComponent(el));
+            });
+            var templatesToApply = new Set(selectedTemplates);
+            if (previewKey) {
+                if (templatesToApply.has(previewKey)) templatesToApply.delete(previewKey);
+                else templatesToApply.add(previewKey);
+            }
+            templatesToApply.forEach(function(k) {
+                params.push("overlay_templates=" + encodeURIComponent(k));
+            });
+            var qs = params.length ? "?" + params.join("&") : "";
+            window.location.href = plotConfig.classifyUrl + qs;
+        }
+
+        document.querySelectorAll("#best-matches-table .best-match-row").forEach(function(row) {
+            var snType = row.getAttribute("data-sn-type");
+            var age = row.getAttribute("data-age");
+            if (!snType || !age) return;
+            row.addEventListener("mouseenter", function() {
+                var key = templateKey(snType, age);
+                applyOverlaysWithPreviewTemplate(key);
+            });
+        });
+
         var snSelect = document.getElementById("custom-sn-type");
         var ageSelect = document.getElementById("custom-age");
         if (snSelect && ageSelect) {
-            fetch(apiBase + "/analysis-options").then(function(r) { return r.json(); }).then(function(data) {
+            fetch(plotConfig.analysisOptionsUrl).then(function(r) { return r.json(); }).then(function(data) {
                 var ageBinsByType = data.age_bins_by_type || {};
                 (data.sn_types || []).forEach(function(st) {
                     var opt = document.createElement("option");

--- a/app/astrodash/templates/astrodash/model_selection.html
+++ b/app/astrodash/templates/astrodash/model_selection.html
@@ -33,20 +33,6 @@
                 <p class="lead text-muted">Select the machine learning model for classification</p>
             </div>
 
-            <!-- Messages -->
-            {% if messages %}
-            <div class="mb-4">
-                {% for message in messages %}
-                <div class="alert alert-{{ message.tags }} alert-dismissible fade show" role="alert">
-                    {{ message }}
-                    <button type="button" class="close" data-dismiss="alert" aria-label="Close">
-                        <span aria-hidden="true">&times;</span>
-                    </button>
-                </div>
-                {% endfor %}
-            </div>
-            {% endif %}
-
             <form method="post" enctype="multipart/form-data" id="modelSelectionForm">
                 {% csrf_token %}
                 {{ form.action_type }}

--- a/app/astrodash/ui_views.py
+++ b/app/astrodash/ui_views.py
@@ -26,6 +26,7 @@ from bokeh.plotting import figure
 from bokeh.models import ColumnDataSource, HoverTool, Span, Label
 import json
 import base64
+import hashlib
 from django.core.files.uploadedfile import SimpleUploadedFile
 
 
@@ -142,10 +143,6 @@ def model_selection(request):
     """
     Handles model selection page - allows choosing between dash/transformer or uploading a custom model.
     """
-    # Clear messages carried over from other pages (e.g. classify/batch processing errors)
-    # so the model selection page doesn't show unrelated errors.
-    list(messages.get_messages(request))
-
     action_type = request.GET.get('action', 'classify')  # 'classify' or 'batch'
     form = ModelSelectionForm(request.POST or None, request.FILES or None)
 
@@ -416,6 +413,7 @@ def classify(request):
         if not has_overlay_qs:
             request.session.pop('classify_uploaded_file', None)
             request.session.pop('classify_last_params', None)
+            request.session.pop('classify_input_source_key', None)
             context['persisted_file_name'] = None
 
     # GET with overlay params: re-render plot from session with new overlays (no re-classification)
@@ -521,21 +519,42 @@ def classify(request):
                 'zValue': form.cleaned_data['redshift'],
                 'modelType': model_type if model_type != 'user_uploaded' else 'transformer',  # Fallback for display
             }
+            default_form = ClassifyForm()
+            default_params = {
+                'smoothing': default_form.fields['smoothing'].initial,
+                'minWave': default_form.fields['min_wave'].initial,
+                'maxWave': default_form.fields['max_wave'].initial,
+                'knownZ': bool(default_form.fields['known_z'].initial),
+                'zValue': default_form.fields['redshift'].initial,
+            }
 
+            current_source_key = None
             if supernova_name:
+                current_source_key = f"object:{supernova_name.strip().lower()}"
                 # Source switched to object lookup; clear cached uploaded-file payload.
                 request.session.pop('classify_uploaded_file', None)
             elif uploaded_file:
-                if not injected_cached_file:
+                if injected_cached_file:
+                    current_source_key = (request.session.get('classify_uploaded_file') or {}).get('source_key')
+                else:
                     upload_name = getattr(uploaded_file, 'name', 'uploaded_spectrum.dat')
                     upload_type = getattr(uploaded_file, 'content_type', None) or 'application/octet-stream'
                     file_bytes = uploaded_file.read()
                     uploaded_file.seek(0)
+                    file_hash = hashlib.sha256(file_bytes).hexdigest()
+                    current_source_key = f"file:{file_hash}"
                     request.session['classify_uploaded_file'] = {
                         'name': upload_name,
                         'content_type': upload_type,
                         'content_b64': base64.b64encode(file_bytes).decode('ascii'),
+                        'source_key': current_source_key,
                     }
+
+            previous_source_key = request.session.get('classify_input_source_key')
+            source_changed = bool(previous_source_key and current_source_key and current_source_key != previous_source_key)
+            if source_changed:
+                params.update(default_params)
+            request.session['classify_input_source_key'] = current_source_key
 
             try:
                 # Reuse the service logic
@@ -666,6 +685,18 @@ def classify(request):
                     'available_elements': available_elements,
                     'persisted_file_name': (request.session.get('classify_uploaded_file') or {}).get('name'),
                 })
+                if source_changed:
+                    replacement_form = ClassifyForm(
+                        initial={'supernova_name': supernova_name} if supernova_name else None
+                    )
+                    replacement_form.fields['model'].initial = (
+                        'user_uploaded' if selected_model_type == 'user_uploaded' else selected_model_type
+                    )
+                    if selected_model_type != 'user_uploaded':
+                        replacement_form.fields['model'].choices = [
+                            c for c in replacement_form.fields['model'].choices if c[0] != 'user_uploaded'
+                        ]
+                    context['form'] = replacement_form
                 
             except AppException as e:
                 messages.error(request, f"Processing Error: {e.message}")

--- a/app/astrodash/ui_views.py
+++ b/app/astrodash/ui_views.py
@@ -384,14 +384,15 @@ def classify(request):
     if request.method == 'GET' and request.session.get('classify_processed'):
         overlay_elements_get = request.GET.getlist('overlay_elements')
         overlay_templates_get = request.GET.getlist('overlay_templates')
-        if overlay_elements_get or overlay_templates_get:
+        overlay_apply_get = request.GET.get('overlay_apply') == '1'
+        if overlay_apply_get or overlay_elements_get or overlay_templates_get:
             stored = request.session['classify_processed']
             try:
                 from types import SimpleNamespace
                 processed = SimpleNamespace(x=stored['x'], y=stored['y'])
             except (KeyError, TypeError):
                 processed = None
-            if processed and (overlay_elements_get or overlay_templates_get):
+            if processed:
                 plot_wave_min = request.session.get('classify_plot_wave_min')
                 plot_wave_max = request.session.get('classify_plot_wave_max')
                 show_templates_section = request.session.get('classify_show_templates_section', False)

--- a/app/astrodash/ui_views.py
+++ b/app/astrodash/ui_views.py
@@ -25,6 +25,8 @@ from bokeh.embed import components
 from bokeh.plotting import figure
 from bokeh.models import ColumnDataSource, HoverTool, Span, Label
 import json
+import base64
+from django.core.files.uploadedfile import SimpleUploadedFile
 
 
 logger = get_logger(__name__)
@@ -354,7 +356,30 @@ def classify(request):
         messages.warning(request, "Please select an uploaded model again.")
         return HttpResponseRedirect(reverse('astrodash:model_selection') + '?action=classify')
 
-    form = ClassifyForm(request.POST or None, request.FILES or None)
+    form_files = request.FILES or None
+    injected_cached_file = False
+    if request.method == 'POST':
+        posted_supernova_name = (request.POST.get('supernova_name') or '').strip()
+        posted_file = request.FILES.get('file')
+        cached_file = request.session.get('classify_uploaded_file')
+        # Browsers clear file inputs after submit; if the user submits again with no new
+        # source selected, reuse the previously uploaded file from session.
+        if not posted_file and not posted_supernova_name and isinstance(cached_file, dict):
+            try:
+                raw_content = base64.b64decode(cached_file.get('content_b64', ''), validate=True)
+                restored_file = SimpleUploadedFile(
+                    name=cached_file.get('name') or 'uploaded_spectrum.dat',
+                    content=raw_content,
+                    content_type=cached_file.get('content_type') or 'application/octet-stream',
+                )
+                form_files = request.FILES.copy()
+                form_files['file'] = restored_file
+                injected_cached_file = True
+            except Exception:
+                # If cached file restore fails, continue with original request files.
+                form_files = request.FILES or None
+
+    form = ClassifyForm(request.POST or None, form_files)
     # Set the model from session (for validation and display)
     form.fields['model'].initial = (
         'user_uploaded' if selected_model_type == 'user_uploaded' else selected_model_type
@@ -378,7 +403,20 @@ def classify(request):
         'selected_model_type': selected_model_type,
         'selected_model_id': selected_model_id,
         'selected_model_display': selected_model_display,
+        'persisted_file_name': (request.session.get('classify_uploaded_file') or {}).get('name'),
     }
+
+    # Fresh page entry should not keep a previously persisted file/params.
+    if request.method == 'GET':
+        has_overlay_qs = (
+            request.GET.get('overlay_apply') == '1'
+            or bool(request.GET.getlist('overlay_elements'))
+            or bool(request.GET.getlist('overlay_templates'))
+        )
+        if not has_overlay_qs:
+            request.session.pop('classify_uploaded_file', None)
+            request.session.pop('classify_last_params', None)
+            context['persisted_file_name'] = None
 
     # GET with overlay params: re-render plot from session with new overlays (no re-classification)
     if request.method == 'GET' and request.session.get('classify_processed'):
@@ -445,13 +483,25 @@ def classify(request):
                     'overlay_elements': overlay_elements_get,
                     'overlay_templates': overlay_templates_get,
                     'available_elements': available_elements,
+                    'persisted_file_name': (request.session.get('classify_uploaded_file') or {}).get('name'),
                 })
+                last_params = request.session.get('classify_last_params') or {}
+                if last_params:
+                    overlay_form = ClassifyForm(initial=last_params)
+                    overlay_form.fields['model'].initial = (
+                        'user_uploaded' if selected_model_type == 'user_uploaded' else selected_model_type
+                    )
+                    if selected_model_type != 'user_uploaded':
+                        overlay_form.fields['model'].choices = [
+                            c for c in overlay_form.fields['model'].choices if c[0] != 'user_uploaded'
+                        ]
+                    context['form'] = overlay_form
                 return render(request, 'astrodash/classify.html', context)
             # Fall through to normal render if no overlays or restore failed
 
     if request.method == 'POST':
         if form.is_valid():
-            uploaded_file = request.FILES.get('file')
+            uploaded_file = form_files.get('file') if form_files else None
             supernova_name = form.cleaned_data.get('supernova_name')
 
             # Use model from session, not form (form model field only affects validation)
@@ -471,6 +521,21 @@ def classify(request):
                 'zValue': form.cleaned_data['redshift'],
                 'modelType': model_type if model_type != 'user_uploaded' else 'transformer',  # Fallback for display
             }
+
+            if supernova_name:
+                # Source switched to object lookup; clear cached uploaded-file payload.
+                request.session.pop('classify_uploaded_file', None)
+            elif uploaded_file:
+                if not injected_cached_file:
+                    upload_name = getattr(uploaded_file, 'name', 'uploaded_spectrum.dat')
+                    upload_type = getattr(uploaded_file, 'content_type', None) or 'application/octet-stream'
+                    file_bytes = uploaded_file.read()
+                    uploaded_file.seek(0)
+                    request.session['classify_uploaded_file'] = {
+                        'name': upload_name,
+                        'content_type': upload_type,
+                        'content_b64': base64.b64encode(file_bytes).decode('ascii'),
+                    }
 
             try:
                 # Reuse the service logic
@@ -531,6 +596,14 @@ def classify(request):
                 request.session['classify_show_templates_section'] = show_templates_section
                 request.session['classify_plot_wave_min'] = plot_wave_min
                 request.session['classify_plot_wave_max'] = plot_wave_max
+                request.session['classify_last_params'] = {
+                    'supernova_name': supernova_name,
+                    'smoothing': params['smoothing'],
+                    'min_wave': params['minWave'],
+                    'max_wave': params['maxWave'],
+                    'known_z': params['knownZ'],
+                    'redshift': params['zValue'],
+                }
 
                 # Overlay state from POST (when user clicked Apply in Customize modal), else empty
                 overlay_elements = request.POST.getlist('overlay_elements') or []
@@ -591,6 +664,7 @@ def classify(request):
                     'overlay_elements': overlay_elements,
                     'overlay_templates': overlay_templates,
                     'available_elements': available_elements,
+                    'persisted_file_name': (request.session.get('classify_uploaded_file') or {}).get('name'),
                 })
                 
             except AppException as e:


### PR DESCRIPTION
## Fixes # 37 
Hover over the Best Matches should show corresponding template overlaid in the main plot by default #37


## Changes

- [x] added JS shortcut to "customize plot" functionality when hovering
- [x] made it toggle instead of just activate, so hovering can turn templates on or off
- [x] changed ui views to accept customize plot params to be empty so page doesn't refresh when removing all templates  


## Fixes # 27
Upload button does not specify that two column file needs a whitespace separator - comma doesn’t work #27 

## Changes
- [x] added support for comma separated .txt files
- [x] changed welcome message to detail what file formats are supported 

## Fixes #28 
Resetting settings after uploading new object

## Changes
- [x] reset settings after uploading new file, inputting a new name, or switching from file to name
- [x] reset settings after navigating away and back from page
- [x] cache uploaded file (so users can change parameters and click classify again without having to reupload)  

## Fixes #32 
Error messages are silent, print all at once

## Changes
 - [x] removed printing messages in model selection page
 - [x] centralized error messaging service to print in the page where it happened 
 - [x] error message is its own text box, displayed prominently in the middle of the page
