### PR TITLE
Fix/twins search numba py313 fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,4 +150,3 @@ quiverMaps/
 # Astrodash local
 app/astrodash/explorer/dash_twinsfromspace.html
 astrodash-logs/
-app/astrodash/tests/

--- a/app/astrodash/domain/services/twins_search_service.py
+++ b/app/astrodash/domain/services/twins_search_service.py
@@ -9,9 +9,11 @@ user-uploaded spectrum).
 
 import json
 import pickle
+import warnings
 from pathlib import Path
 
 import numpy as np
+from sklearn.exceptions import InconsistentVersionWarning
 
 from astrodash.config.logging import get_logger
 
@@ -52,8 +54,17 @@ class TwinsSearchService:
         self._embeddings = np.load(emb_path).astype(np.float32)
         with open(umap_path, "rb") as f:
             self._umap = pickle.load(f)
-        with open(pca_path, "rb") as f:
-            self._pca = pickle.load(f)
+        # The pickled PCA was serialized by an older sklearn (currently 1.8.0
+        # vs the runtime 1.9.0+), which surfaces an InconsistentVersionWarning
+        # on every load. PCA pickles tend to survive minor sklearn bumps
+        # cleanly — and this one does, find_twins returns sensible PCA coords
+        # — so the warning is informational noise. Silence it only at this
+        # specific load site so other (legitimately different) version
+        # mismatches elsewhere still surface.
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", InconsistentVersionWarning)
+            with open(pca_path, "rb") as f:
+                self._pca = pickle.load(f)
         with open(payload_path, "r") as f:
             payload = json.load(f)
         # Only the 2D coordinate arrays are needed at query time — the rest of the

--- a/app/astrodash/domain/services/twins_search_service.py
+++ b/app/astrodash/domain/services/twins_search_service.py
@@ -6,6 +6,8 @@ Loads precomputed embeddings and fitted UMAP/PCA from the explorer artifacts
 cosine-similarity search and 2D projection for a query embedding (e.g. from a
 user-uploaded spectrum).
 """
+
+import json
 import pickle
 from pathlib import Path
 
@@ -28,23 +30,37 @@ class TwinsSearchService:
 
         Args:
             explorer_dir: Directory containing dash_twins_embeddings.npy,
-                dash_twins_umap.pkl, dash_twins_pca.pkl.
+                dash_twins_umap.pkl, dash_twins_pca.pkl, and
+                dash_twins_payload.json.
         """
         explorer_dir = Path(explorer_dir)
         emb_path = explorer_dir / "dash_twins_embeddings.npy"
         umap_path = explorer_dir / "dash_twins_umap.pkl"
         pca_path = explorer_dir / "dash_twins_pca.pkl"
+        payload_path = explorer_dir / "dash_twins_payload.json"
         for p, name in [(emb_path, "embeddings"), (umap_path, "UMAP"), (pca_path, "PCA")]:
             if not p.is_file():
                 raise FileNotFoundError(
                     f"Twins artifact not found: {p}. Run extract_payload.py --build-artifacts."
                 )
+        if not payload_path.is_file():
+            raise FileNotFoundError(
+                f"Twins artifact not found: {payload_path}. "
+                f"Run extract_payload.py --build-artifacts."
+            )
 
         self._embeddings = np.load(emb_path).astype(np.float32)
         with open(umap_path, "rb") as f:
             self._umap = pickle.load(f)
         with open(pca_path, "rb") as f:
             self._pca = pickle.load(f)
+        with open(payload_path, "r") as f:
+            payload = json.load(f)
+        # Only the 2D coordinate arrays are needed at query time — the rest of the
+        # payload (spectra_db, names, types, phases, etc.) is served separately to
+        # the frontend by dash_twins_data.
+        self._umap_xy = (payload.get("umap_x", []), payload.get("umap_y", []))
+        self._pca_xy = (payload.get("pca_x", []), payload.get("pca_y", []))
 
         n, dim = self._embeddings.shape
         if dim != 1024:
@@ -98,10 +114,36 @@ class TwinsSearchService:
         twin_indices = top_k.tolist()
         twin_similarities = sims[top_k].tolist()
 
-        # Project query into 2D
+        # Project query into 2D. Both UMAP and PCA transforms wrap in
+        # try/except: on failure, fall back to the nearest twin's coordinates
+        # from the payload so the dot in the explorer lands in the right
+        # neighborhood instead of failing the whole request.
+        #
+        # The UMAP fallback exists because under Python 3.13 + numba 0.65.1
+        # + umap-learn 0.5.12, JIT-compiling the distance metric panics in
+        # numba's bytecode interpreter (byteflow.py:1641 op_BINARY_OP pops
+        # from an empty stack and raises IndexError('pop from empty list')).
+        # Both sklearn's callable-metric path and umap-learn's own
+        # pairwise_special_metric fallback trigger the same JIT compilation
+        # and panic identically. PCA goes through pure sklearn (no numba)
+        # and shouldn't be affected, but the symmetric fallback keeps the
+        # endpoint functional if anything analogous surfaces later.
         q_2d = q.reshape(1, -1)
-        query_umap = self._umap.transform(q_2d)[0].tolist()
-        query_pca = self._pca.transform(q_2d)[0].tolist()
+        nearest_idx = int(twin_indices[0])
+        query_umap = self._project_with_fallback(
+            self._umap.transform,
+            q_2d,
+            self._umap_xy,
+            nearest_idx,
+            label="UMAP",
+        )
+        query_pca = self._project_with_fallback(
+            self._pca.transform,
+            q_2d,
+            self._pca_xy,
+            nearest_idx,
+            label="PCA",
+        )
 
         return {
             "query_umap": [float(query_umap[0]), float(query_umap[1])],
@@ -109,3 +151,27 @@ class TwinsSearchService:
             "twin_indices": twin_indices,
             "twin_similarities": twin_similarities,
         }
+
+    @staticmethod
+    def _project_with_fallback(transform, q_2d, payload_xy, nearest_idx, label):
+        """Call ``transform(q_2d)`` and return the 2D coords as a list of two
+        floats. On any exception, log it and fall back to the nearest twin's
+        coordinates from ``payload_xy`` (a (xs, ys) tuple of arrays indexed
+        the same as the payload). Raises ``IndexError`` only if the fallback
+        path is needed but the payload arrays are empty — that means the
+        artifact set is incomplete and the operator needs to rebuild it.
+        """
+        try:
+            return transform(q_2d)[0].tolist()
+        except Exception as exc:
+            xs, ys = payload_xy
+            logger.warning(
+                "%s transform failed (%s: %s); falling back to nearest "
+                "twin's %s coordinates (twin index %d).",
+                label,
+                type(exc).__name__,
+                exc,
+                label,
+                nearest_idx,
+            )
+            return [float(xs[nearest_idx]), float(ys[nearest_idx])]

--- a/app/astrodash/tests/test_twins_search_service.py
+++ b/app/astrodash/tests/test_twins_search_service.py
@@ -1,0 +1,155 @@
+"""Tests for the Twins Search service's umap/pca-transform fallback path.
+
+Under Python 3.13 + numba 0.65.1 + umap-learn 0.5.12, JIT-compiling
+umap-learn's distance metric panics in numba's bytecode interpreter
+(``byteflow.py:1641 op_BINARY_OP`` pops from an empty stack and raises
+``IndexError('pop from empty list')``). Both sklearn's callable-metric
+path and umap-learn's ``pairwise_special_metric`` fallback trigger the
+same JIT compilation and panic identically — there's no try/except
+shape that lets the in-library transform succeed.
+
+The fix is to fall back to the nearest twin's payload coordinates so
+the visualization lands in the right neighborhood instead of failing
+the whole request.
+"""
+
+from unittest.mock import Mock
+
+import numpy as np
+from django.test import SimpleTestCase
+
+from astrodash.domain.services.twins_search_service import TwinsSearchService
+
+
+class ProjectWithFallbackTests(SimpleTestCase):
+    """Unit tests for the ``_project_with_fallback`` helper in isolation."""
+
+    def test_success_passes_through_transform_output(self):
+        """When transform succeeds, the helper returns its 2D coords
+        unchanged — no fallback path taken."""
+        transform = Mock(return_value=np.array([[1.5, 2.5]]))
+        out = TwinsSearchService._project_with_fallback(
+            transform,
+            np.zeros((1, 1024)),
+            ([10.0, 20.0], [100.0, 200.0]),
+            0,
+            label="UMAP",
+        )
+        self.assertEqual(out, [1.5, 2.5])
+        transform.assert_called_once()
+
+    def test_index_error_pop_from_empty_list_falls_back(self):
+        """The numba bytecode panic shape triggers the fallback path."""
+
+        def transform(_):
+            raise IndexError("pop from empty list")
+
+        out = TwinsSearchService._project_with_fallback(
+            transform,
+            np.zeros((1, 1024)),
+            ([10.0, 20.0, 30.0], [100.0, 200.0, 300.0]),
+            1,
+            label="UMAP",
+        )
+        self.assertEqual(out, [20.0, 200.0])
+
+    def test_unrelated_exception_also_falls_back(self):
+        """The fallback is intentionally broad — any exception from
+        transform routes through the nearest-twin path so the endpoint
+        keeps producing a renderable response."""
+
+        def transform(_):
+            raise ValueError("something unrelated")
+
+        out = TwinsSearchService._project_with_fallback(
+            transform,
+            np.zeros((1, 1024)),
+            ([10.0, 20.0], [100.0, 200.0]),
+            0,
+            label="PCA",
+        )
+        self.assertEqual(out, [10.0, 100.0])
+
+
+class FindTwinsFallbackTests(SimpleTestCase):
+    """Higher-level tests for the find_twins endpoint behavior with mocked
+    UMAP and PCA components, exercising the fallback wiring end-to-end."""
+
+    @staticmethod
+    def _build_service(umap_mock, pca_mock):
+        """Construct a TwinsSearchService without running __init__ (which
+        requires real artifact files on disk). Populates the minimal
+        attribute surface ``find_twins`` reads.
+
+        The mocked normed-embedding matrix is rigged so that the query
+        ``[1, 0, ..., 0]`` selects row 2 as the nearest twin.
+        """
+        svc = TwinsSearchService.__new__(TwinsSearchService)
+        dim = 1024
+        n = 5
+        embeddings = np.zeros((n, dim), dtype=np.float32)
+        embeddings[2, 0] = 1.0
+        svc._embeddings = embeddings
+        norms = np.linalg.norm(embeddings, axis=1, keepdims=True)
+        norms = np.clip(norms, 1e-10, None)
+        svc._normed = (embeddings / norms).astype(np.float32)
+        svc._n = n
+        svc._dim = dim
+        svc._umap = umap_mock
+        svc._pca = pca_mock
+        svc._umap_xy = (
+            [0.0, 0.1, 0.2, 0.3, 0.4],
+            [1.0, 1.1, 1.2, 1.3, 1.4],
+        )
+        svc._pca_xy = (
+            [10.0, 10.1, 10.2, 10.3, 10.4],
+            [100.0, 100.1, 100.2, 100.3, 100.4],
+        )
+        return svc
+
+    def _query_vector(self):
+        q = np.zeros(1024, dtype=np.float32)
+        q[0] = 1.0
+        return q
+
+    def test_umap_transform_failure_uses_nearest_twin_umap_coords(self):
+        umap_mock = Mock()
+        umap_mock.transform.side_effect = IndexError("pop from empty list")
+        pca_mock = Mock()
+        pca_mock.transform.return_value = np.array([[7.0, 8.0]])
+
+        svc = self._build_service(umap_mock, pca_mock)
+        out = svc.find_twins(self._query_vector(), k=3)
+
+        # Row 2 is the nearest twin; UMAP falls back to payload index 2.
+        self.assertEqual(out["twin_indices"][0], 2)
+        self.assertEqual(out["query_umap"], [0.2, 1.2])
+        # PCA succeeded — its output is preserved.
+        self.assertEqual(out["query_pca"], [7.0, 8.0])
+
+    def test_pca_transform_failure_uses_nearest_twin_pca_coords(self):
+        umap_mock = Mock()
+        umap_mock.transform.return_value = np.array([[5.5, 6.6]])
+        pca_mock = Mock()
+        pca_mock.transform.side_effect = RuntimeError("sklearn imploded")
+
+        svc = self._build_service(umap_mock, pca_mock)
+        out = svc.find_twins(self._query_vector(), k=3)
+
+        self.assertEqual(out["twin_indices"][0], 2)
+        self.assertEqual(out["query_umap"], [5.5, 6.6])
+        self.assertEqual(out["query_pca"], [10.2, 100.2])
+
+    def test_both_transforms_succeed_no_fallback_taken(self):
+        umap_mock = Mock()
+        umap_mock.transform.return_value = np.array([[5.5, 6.6]])
+        pca_mock = Mock()
+        pca_mock.transform.return_value = np.array([[7.0, 8.0]])
+
+        svc = self._build_service(umap_mock, pca_mock)
+        out = svc.find_twins(self._query_vector(), k=3)
+
+        self.assertEqual(out["query_umap"], [5.5, 6.6])
+        self.assertEqual(out["query_pca"], [7.0, 8.0])
+        self.assertEqual(len(out["twin_indices"]), 3)
+        self.assertEqual(len(out["twin_similarities"]), 3)


### PR DESCRIPTION
fall back to nearest-twin coords when twins transform panics

