### PR TITLE
feat: derive local-dev version footer from git describe

### DIFF
--- a/app/astrodash/tests/test_compose_app_version.py
+++ b/app/astrodash/tests/test_compose_app_version.py
@@ -1,0 +1,108 @@
+"""Regression guard: ``docker-compose.dev.yaml`` carries the APP_VERSION line.
+
+Without this guard, a future compose edit can silently drop
+``APP_VERSION=${APP_VERSION:-local}`` from the app service's ``environment:``
+block. When that happens, ``astrodashctl full_dev up`` still exports the
+git-describe value on the host, but the value never reaches the container
+and the footer reverts to the literal ``local`` — the same footer we saw
+before the local-dev version work landed.
+
+The guard scans the compose file with a small regex rather than parsing
+YAML. Pattern-matching mirrors the shape of
+``test_no_version_literals.py`` from the parent brainstorm and keeps the
+test resilient to whitespace or quote-style reformatting.
+
+Covers R4 in
+``docs/brainstorms/2026-07-01-local-dev-app-version-requirements.md``.
+"""
+
+import re
+import unittest
+from pathlib import Path
+from typing import Final
+
+from django.test import SimpleTestCase
+
+
+# The literal token that must appear in ``docker/docker-compose.dev.yaml``:
+#
+#     APP_VERSION=${APP_VERSION:-local}
+#
+# The compose file quotes its ``environment:`` entries as strings, so the
+# form in the file is ``- "APP_VERSION=${APP_VERSION:-local}"`` (or the
+# single-quoted equivalent). The regex is written against the token itself
+# and does not care which quote style wraps it.
+APP_VERSION_LINE_PATTERN: Final[re.Pattern[str]] = re.compile(
+    r"APP_VERSION=\$\{APP_VERSION:-local\}"
+)
+
+# ``Path(__file__).resolve().parents[3]`` steps: tests/ -> astrodash/ -> app/ ->
+# repo root. Four hops from this file. This assumes the tests run from a
+# checkout where ``docker/docker-compose.dev.yaml`` sits at the repo root — true
+# for host-side runs (``pytest`` at repo root, CI). Inside the dev container
+# only ``app/`` is bind-mounted, so ``docker/`` isn't reachable — the live scan
+# skips itself in that context. The pattern tests below still fire either way.
+REPO_ROOT: Final[Path] = Path(__file__).resolve().parents[3]
+COMPOSE_FILE: Final[Path] = REPO_ROOT / "docker" / "docker-compose.dev.yaml"
+
+
+class ComposeAppVersionLineTests(SimpleTestCase):
+    """The dev compose file must carry the ``APP_VERSION`` env-var entry."""
+
+    @unittest.skipUnless(
+        COMPOSE_FILE.exists(),
+        f"{COMPOSE_FILE} not reachable — likely running from inside the dev "
+        "container, where only app/ is bind-mounted. Run the suite from the "
+        "repo root on the host to exercise this scan.",
+    )
+    def test_live_compose_file_contains_app_version_entry(self) -> None:
+        """The live ``docker/docker-compose.dev.yaml`` file matches the guard.
+
+        The compose file's app service must include
+        ``APP_VERSION=${APP_VERSION:-local}`` in its ``environment:`` block so
+        the value exported by ``run/astrodashctl`` reaches the container.
+        """
+        text = COMPOSE_FILE.read_text(encoding="utf-8")
+        self.assertTrue(
+            APP_VERSION_LINE_PATTERN.search(text),
+            f"Expected {COMPOSE_FILE.relative_to(REPO_ROOT)} to contain "
+            f"``APP_VERSION=${{APP_VERSION:-local}}`` in the app service's "
+            f"``environment:`` block. Without it, ``astrodashctl full_dev up`` "
+            f"exports the git-describe value on the host but the value never "
+            f"reaches the container, and the footer reverts to ``local``.",
+        )
+
+
+class GuardPatternTests(SimpleTestCase):
+    """Unit tests for the guard's regex.
+
+    The live scan above proves the guard passes today. These tests prove
+    the guard would FIRE if a regression were introduced — closing the gap
+    where a future edit could silently weaken the pattern without breaking
+    the suite.
+    """
+
+    def test_matches_double_quoted_compose_entry(self) -> None:
+        """The double-quoted YAML list form matches."""
+        line = '      - "APP_VERSION=${APP_VERSION:-local}"'
+        self.assertIsNotNone(APP_VERSION_LINE_PATTERN.search(line))
+
+    def test_matches_single_quoted_compose_entry(self) -> None:
+        """The single-quoted YAML list form also matches."""
+        line = "      - 'APP_VERSION=${APP_VERSION:-local}'"
+        self.assertIsNotNone(APP_VERSION_LINE_PATTERN.search(line))
+
+    def test_does_not_match_when_line_is_missing(self) -> None:
+        """A compose fragment with the APP_VERSION entry removed fails the guard."""
+        yaml_fragment = (
+            "    environment:\n"
+            '      - "DEV_MODE=1"\n'
+            '      - "ASTRO_DASH_CORS_ALLOWED_ORIGINS=*"\n'
+            '      - "ASTRODASH_LOG_LEVEL=DEBUG"\n'
+        )
+        self.assertIsNone(APP_VERSION_LINE_PATTERN.search(yaml_fragment))
+
+    def test_does_not_match_bare_app_version_assignment(self) -> None:
+        """``APP_VERSION=`` without the ``${APP_VERSION:-local}`` fallback fails."""
+        line = '      - "APP_VERSION="'
+        self.assertIsNone(APP_VERSION_LINE_PATTERN.search(line))

--- a/docker/docker-compose.dev.yaml
+++ b/docker/docker-compose.dev.yaml
@@ -35,6 +35,7 @@ services:
       - 127.0.0.1:8000:${WEB_APP_PORT}
     environment:
       - "DEV_MODE=1"
+      - "APP_VERSION=${APP_VERSION:-local}"
       - "ASTRO_DASH_CORS_ALLOWED_ORIGINS=*"
       - "ASTRODASH_LOG_LEVEL=DEBUG"
     env_file:

--- a/docs/brainstorms/2026-07-01-local-dev-app-version-requirements.md
+++ b/docs/brainstorms/2026-07-01-local-dev-app-version-requirements.md
@@ -1,0 +1,81 @@
+---
+date: 2026-07-01
+topic: local-dev-app-version
+---
+
+# Local-Dev APP_VERSION from git describe
+
+## Summary
+
+Extend the APP_VERSION source-of-truth mechanism to the local docker-compose dev flow. On the `full_dev` and `slim_dev` profiles, `run/astrodashctl` computes `git describe --tags --always` on the host and exports it, and `docker/docker-compose.dev.yaml` reads it into the app container's `APP_VERSION` env var. The footer, `/healthz`, and startup log all show the git-describe string instead of the `local` placeholder. Non-dev profiles and raw `docker compose up` outside `astrodashctl` continue to fall back to `local`.
+
+## Problem Frame
+
+The 2026-06-25 brainstorm (`docs/brainstorms/2026-06-25-version-source-of-truth-requirements.md`) landed on a deliberate `local` placeholder for any environment without `APP_VERSION` set. In production that value never appears — the Helm chart always sets `APP_VERSION` from `.Values.image.tag`. But local docker-compose is the second most common runtime shape for this app, and there the footer always reads `local`.
+
+When a developer runs multiple checkouts, worktrees, or branches through the same docker-compose stack — routine here, especially with `.worktrees/feat-<x>` alongside `main` — the footer is silent about which one is loaded. The developer can still verify code identity by inspecting the container or the mounted `app/` directory, but the fastest signal (the footer, designed to report what's running) carries no information.
+
+The plumbing to fix this already exists. `run/astrodashctl` is the canonical bash launcher and already exports env vars before invoking `docker compose`. `docker/docker-compose.dev.yaml`'s app service already has an `environment:` block. `settings.APP_VERSION` already reads the env var. The missing link is astrodashctl computing `git describe` on the host and exporting it, plus one env-var entry in the compose overlay.
+
+## Key Decisions
+
+- **Host-side git describe, mirroring the Helm shape.** `astrodashctl` computes `git describe --tags --always` on the host at up-time and exports `APP_VERSION`; `docker-compose.dev.yaml` adds `APP_VERSION=${APP_VERSION:-local}` to the app service `environment:` block; the Django app reads `APP_VERSION` unchanged. The docker-compose flow becomes structurally symmetric with the Helm flow: external orchestrator sets env, container reads env. No new container binary (`git`), no new mount (`.git`). Container-side computation (bind-mount `.git`, install git in the dev image) is deferred; if raw `docker compose up` outside `astrodashctl` becomes a first-class launch path, revisit.
+
+- **Snapshot at up-time, not live per request.** The value is fixed by whatever `git describe` returned when `astrodashctl full_dev up` was invoked; `docker compose restart app` alone doesn't re-interpolate. The `--dirty` flag is intentionally omitted from the git describe invocation because the dev overlay bind-mounts `../app:/app`: running code diverges from the snapshotted working-tree state the moment anyone edits after `up`, and a stale `-dirty` (or worse, a stale non-dirty) suffix would report false state with authoritative styling. Commit-level staleness — a new commit after `up` doesn't refresh the footer until the next `up` — is accepted, because the tag + short-commit portion still discriminates worktrees, which is what the Problem Frame actually needs.
+
+- **Dev profiles only.** `full_dev` and `slim_dev` get the git-describe treatment. `full_prod`, `slim_prod`, `ci`, and `docs` keep the `local` placeholder — prod compose profiles are local prod simulation with a different intent, and CI runs often have shallow or detached checkouts that would produce noisy `--dirty` or short-hash output.
+
+- **Display the git-describe string verbatim.** No parsing, no synthesis, no stripping of the abbreviated-commit tail. The footer renders the raw string; the release-link target is `.../releases/tag/<the-same-string>`. That link 404s by design when the string isn't a real release tag, matching the "clearly not a release" affordance the 2026-06-25 brainstorm established for the `local` placeholder in its AE3.
+
+- **No Django source changes.** `resolve_app_version()` in `app/astrodash_project/settings.py`, the `app_version` template tag, `get_health_status()`, and `AstroDashConfig.ready()` already read `settings.APP_VERSION`. A git-describe string flows through the existing pipeline unchanged.
+
+## Requirements
+
+### astrodashctl (host-side)
+
+- R1. `run/astrodashctl`, when invoked with `full_dev` or `slim_dev`, computes `git describe --tags --always 2>/dev/null || echo local` and exports the result as `APP_VERSION` before invoking `docker compose ... up`. The computation runs after profile switching but before the compose invocation.
+- R2. A pre-existing `APP_VERSION` in the invoker's environment is preserved. `astrodashctl` only computes and exports when `APP_VERSION` is unset or empty, so `APP_VERSION=foo run/astrodashctl full_dev up` renders `foo` in the footer.
+- R3. Non-dev profiles (`full_prod`, `slim_prod`, `ci`, `docs`) do not compute or export `APP_VERSION`. Whatever the invoker's environment holds (typically nothing) propagates untouched.
+
+### docker-compose
+
+- R4. `docker/docker-compose.dev.yaml`'s app service `environment:` block includes `APP_VERSION=${APP_VERSION:-local}` — passing whatever `astrodashctl` (or the invoker) has in the host environment through to the container, with `local` as the compose-default fallback for launches that bypass `astrodashctl`.
+- R5. No other compose file (`docker-compose.yml`, `docker-compose.prod.yaml`, `docker-compose.ci.yaml`) is modified. Non-dev-profile app containers see whatever `APP_VERSION` is in the invoking environment (typically nothing), and `settings.APP_VERSION` falls back to `local` unchanged.
+
+## Acceptance Examples
+
+- AE1. **Covers R1, R4.** **Given** a developer runs `run/astrodashctl full_dev up` from a checkout where `git describe --tags --always` returns `dev2-v1.1.0-3-gabc1234`, **when** they load any page served by the dev stack, **then** the footer shows `// dev2-v1.1.0-3-gabc1234` and the release link target is `https://github.com/scimma/astrodash/releases/tag/dev2-v1.1.0-3-gabc1234` (a 404, consistent with AE3 of the 2026-06-25 brainstorm).
+- AE2. **Covers R2.** **Given** a developer runs `APP_VERSION=custom-value run/astrodashctl full_dev up`, **when** they load the footer, **then** the displayed value is `custom-value` — the pre-existing env var is preserved and passes through to the app container.
+- AE3. **Covers R1, R4.** **Given** a developer runs `run/astrodashctl full_dev up` from a checkout where `git describe --tags --always` fails (no tags reachable and `--always` also fails, e.g. a broken `.git`), **when** they load the footer, **then** the displayed value is `local` — astrodashctl's `|| echo local` fallback fires.
+- AE4. **Covers R3, R5.** **Given** a developer runs `run/astrodashctl full_prod up` (local prod simulation) or `run/astrodashctl ci up`, **when** the app container starts, **then** the footer shows `local`. `astrodashctl` doesn't compute `git describe` for these profiles, and their compose overlays don't define `APP_VERSION`, so `settings.APP_VERSION` falls back to `local` in the Django layer.
+- AE5. **Covers R4.** **Given** a developer runs `docker compose --file docker/docker-compose.yml --file docker/docker-compose.dev.yaml --profile full_dev up` directly (bypassing `astrodashctl`) with no pre-set `APP_VERSION` in the invoking environment, **when** the app container starts, **then** the footer shows `local` — the compose file's `${APP_VERSION:-local}` default fires.
+
+## Scope Boundaries
+
+- **Container-side computation (Approach B) is deferred.** Bind-mounting `.git` and installing `git` in the dev image would let raw `docker compose up` outside `astrodashctl` still get a meaningful footer, but the trade-off (image dep, `.git` mount, more moving parts) isn't worth it while `astrodashctl` is the canonical launcher.
+- **`full_prod`, `slim_prod`, `ci`, and `docs` profiles keep the `local` placeholder.** Different intent (local prod simulation is not the developer's own code being served); CI checkouts are commonly shallow or detached and would produce noisy output.
+- **Refreshing the footer without a full down/up cycle is out of scope.** A developer who commits new code after `astrodashctl full_dev up` sees the old value in the footer until they re-run `astrodashctl full_dev up` (which re-renders compose and picks up the new host env). `docker compose restart app` alone does not re-render.
+- **The release-link footer target is unchanged.** Still points at `releases/tag/<APP_VERSION>` — a 404 for git-describe values, matching today's 404 for `local`. Not a bug this brainstorm is fixing.
+- **Tag-naming and `git describe` flag variations are not in scope.** The combo `--tags --always` is the default; alternate shapes (`--long`, `--first-parent`, custom `--match` filters) are not explored.
+- **Helm/Kubernetes deploy path is unchanged.** The Helm chart still passes `.Values.image.tag` unchanged. This brainstorm is a parallel dev-side mechanism, not a change to the deploy path.
+
+## Dependencies / Assumptions
+
+- The host running `astrodashctl` has `git` installed and can `git describe` from the repo working directory. `run/astrodashctl:5` `cd`s to the repo root, so the working directory context is correct. If `git` is unavailable or fails, the `|| echo local` fallback fires.
+- `docker compose ... up` interpolates compose files at up-time using the host environment; a value exported before the invocation is picked up by `${APP_VERSION:-local}` in the YAML. `docker compose restart <svc>` does not re-interpolate — refresh requires a full `down` + `up` cycle (or another `up` invocation — compose recreates the service if the env changed).
+- The bind-mounted `app/` directory (`../app:/app` in `docker-compose.dev.yaml:45`) does not include the host's `.git` — that's above the mount. Container-side git commands cannot see the repo without an additional mount, which Approach B would require and this brainstorm defers.
+- `settings.APP_VERSION` still uses the `or "local"` fallback from the 2026-06-25 brainstorm's R1, so any path where the env var doesn't reach the container renders `local` rather than blank or crashing.
+- The existing R5 grep guard (`app/astrodash/tests/test_no_version_literals.py`) scans `.py` files only. YAML and bash changes don't reach the scan; the compose default `local` is not a semver shape and would not trigger even if scanned.
+
+## Outstanding Questions
+
+- Whether a bash smoke test or shellcheck coverage for the astrodashctl change is worth adding — planning decides. The existing Django test suite still passes unchanged.
+- Whether to add a short mention in `docs/` (or a README/runbook entry) pointing developers at the git-describe behavior, or whether the startup log line already emitted by `AstroDashConfig.ready()` is sufficient discovery.
+
+## Sources
+
+- `docs/brainstorms/2026-06-25-version-source-of-truth-requirements.md` — the parent brainstorm this one extends; particularly R1 (the `local` fallback contract) and AE3 (the 404 signal).
+- `app/astrodash_project/settings.py:16` — `resolve_app_version()`, unchanged by this brainstorm.
+- `docker/docker-compose.dev.yaml:36-42` — app service `environment:` and `env_file:` blocks; the insertion point for R4.
+- `run/astrodashctl:5,16-48,69-76` — `cd` to repo root, profile switching, and the `docker compose up` invocation site; the insertion point for R1–R3.
+- `env/.env.default`, `env/.env.dev` — env files loaded into the container; documented for completeness, not modified.

--- a/docs/developer/getting-started.md
+++ b/docs/developer/getting-started.md
@@ -27,3 +27,17 @@ run/astrodash.test.sh slim_dev
 |---------|---------|-------------|
 | `full_dev` | `run/astrodashctl full_dev up` | Web app, database, Redis cache, and nginx |
 | `slim_dev` | `run/astrodashctl slim_dev up` | Web app and database only (no Redis cache) |
+
+### Version string in the footer
+
+On the `full_dev` and `slim_dev` profiles, `astrodashctl` runs `git describe --tags --always` on the host at up-time and exports the result as `APP_VERSION`. The Django app reads it and shows it in the page footer, in the `/healthz` payload, and in the startup log line emitted by `AstroDashConfig.ready()`. So the footer names the commit the stack was launched from — useful when running multiple worktrees or branches side by side.
+
+The value is a snapshot at up-time, not live per request. A commit made after `astrodashctl full_dev up` doesn't refresh the footer until the next `up` (`docker compose restart app` alone does not re-interpolate compose vars). `--dirty` is intentionally omitted: the dev overlay bind-mounts `app/` into the container, so running code diverges from the snapshotted working tree the moment you edit after `up`, and a stale `-dirty` (or non-dirty) suffix would report false state.
+
+To display a specific string instead — for example, when testing what a release tag will render:
+
+```bash
+APP_VERSION=v1.2.3 run/astrodashctl full_dev up
+```
+
+Non-dev profiles (`full_prod`, `slim_prod`, `ci`, `docs`) and running `docker compose up` directly (bypassing `astrodashctl`) fall back to the literal `local`. The operator-side counterpart — how the Helm chart sets `APP_VERSION` on the deployed pod from the image tag — is documented in `docs/operator-runbook.md`.

--- a/docs/plans/2026-07-01-001-feat-local-dev-app-version-plan.md
+++ b/docs/plans/2026-07-01-001-feat-local-dev-app-version-plan.md
@@ -1,0 +1,210 @@
+---
+date: 2026-07-01
+type: feat
+origin: docs/brainstorms/2026-07-01-local-dev-app-version-requirements.md
+---
+
+# feat: Local-dev APP_VERSION from git describe
+
+## Summary
+
+Extend the APP_VERSION source-of-truth mechanism to the local docker-compose dev flow. `run/astrodashctl` computes `git describe --tags --always` on the host for `full_dev` and `slim_dev` and exports it; `docker/docker-compose.dev.yaml` reads it into the app container. The footer, `/healthz`, and startup log show the git-describe string instead of the `local` placeholder. Non-dev profiles and raw `docker compose up` continue to fall back to `local`.
+
+---
+
+## Problem Frame
+
+The 2026-06-25 SSoT work fixed the deployed footer via Helm but left the docker-compose dev flow reading the `local` placeholder unconditionally. When developers run multiple checkouts, worktrees, or branches through the same stack (routine here, especially `.worktrees/feat-<x>` alongside `main`), the footer carries no signal about which checkout is loaded. The plumbing to fix this already exists: `run/astrodashctl` exports env before invoking compose, `docker-compose.dev.yaml`'s app service has an `environment:` block, and `settings.APP_VERSION` already reads the env var (see origin: `docs/brainstorms/2026-07-01-local-dev-app-version-requirements.md`).
+
+---
+
+## Requirements Trace
+
+| R-ID | Requirement | Unit(s) |
+|---|---|---|
+| R1 | `astrodashctl` computes `git describe --tags --always 2>/dev/null \|\| echo local` and exports `APP_VERSION` for `full_dev` and `slim_dev` before `docker compose ... up` | U1 |
+| R2 | A pre-existing `APP_VERSION` in the invoker's environment is preserved (fallback-substitution semantics, not overwrite) | U1 |
+| R3 | Non-dev profiles (`full_prod`, `slim_prod`, `ci`, `docs`) do not compute or export `APP_VERSION` | U1 |
+| R4 | `docker/docker-compose.dev.yaml`'s app service `environment:` includes `APP_VERSION=${APP_VERSION:-local}` | U1 |
+| R5 | No other compose file is modified | U1 (by omission) |
+
+Acceptance examples AE1–AE5 from origin are covered by U1's verification steps below.
+
+---
+
+## Key Technical Decisions
+
+- **Bundle the astrodashctl edit and the compose edit in one commit (U1).** The mechanism only works when both changes land together. Intermediate states are safe (astrodashctl exports but compose doesn't read → env reaches container but nothing changes there without R4; compose reads but astrodashctl doesn't export → footer shows `local`, same as today), so splitting would not create broken bisect states, but the single-commit shape is a clearer review unit for a mechanism change of this size.
+
+- **Bash-native fallback substitution for R2.** Use the shell parameter-expansion form `APP_VERSION="${APP_VERSION:-$(git describe --tags --always 2>/dev/null || echo local)}"`, then `export APP_VERSION`. This preserves a pre-existing set-and-non-empty value (R2), computes lazily otherwise, and never overwrites — no `if [[ -z ... ]]` guard needed. The inner `2>/dev/null || echo local` catches every git-side failure (git binary missing, `.git` missing, no reachable commit) and produces the same sentinel `settings.py` uses.
+
+- **Insert the astrodashctl branch after profile-switching, before compose invocation.** The natural placement is a new `case "$PROFILE"` block (or an amendment to the existing one at `run/astrodashctl:16-48`) between the existing profile switch and the `case "$ACTION"` at line 69. Compose interpolation runs at up-time and reads the shell env, so the export must complete before the `docker compose ... up` line executes.
+
+- **Skip a bash smoke test; shellcheck-clean is the quality bar.** The astrodashctl change is ~5 lines. A dedicated bash test harness for that size is out of proportion. Instead, U3 adds a Django regression guard on the compose YAML (the more likely regression vector — someone edits the compose file and drops the line), and U1 verifies manually via footer inspection.
+
+- **Docs mention lives in the developer docs, symmetric with the parent's operator runbook addition.** The parent brainstorm added `docs/operator-runbook.md` for the K8s deploy story. This one adds a paragraph to `docs/developer/getting-started.md` for the docker-compose dev story. Same symmetry as the mechanism itself.
+
+---
+
+## Implementation Units
+
+### U1. astrodashctl exports git-describe; compose reads it
+
+**Goal:** Make the footer track `git describe --tags --always` (or the invoker's pre-set `APP_VERSION`) whenever `astrodashctl full_dev up` or `astrodashctl slim_dev up` runs.
+
+**Requirements:** R1, R2, R3, R4, R5. Covers origin AE1–AE5.
+
+**Dependencies:** None. This is the mechanism unit.
+
+**Files:**
+- `run/astrodashctl` (modify)
+- `docker/docker-compose.dev.yaml` (modify)
+
+**Approach:**
+
+1. In `run/astrodashctl`, after the profile-switching `case "$PROFILE"` block (currently ends around line 48) and before the compose invocation `case "$ACTION"` block (currently starts around line 69), insert a per-profile branch:
+   - For `full_dev` and `slim_dev`: run `APP_VERSION="${APP_VERSION:-$(git describe --tags --always 2>/dev/null || echo local)}"` then `export APP_VERSION`.
+   - For all other profiles: no-op (leave `APP_VERSION` untouched — R3).
+2. In `docker/docker-compose.dev.yaml`, add `- "APP_VERSION=${APP_VERSION:-local}"` to the app service's `environment:` block (currently lines 36–39, the block already contains `DEV_MODE`, `ASTRO_DASH_CORS_ALLOWED_ORIGINS`, `ASTRODASH_LOG_LEVEL`).
+3. Do not modify `docker/docker-compose.yml`, `docker/docker-compose.prod.yaml`, or `docker/docker-compose.ci.yaml` (R5).
+
+**Patterns to follow:**
+- The existing profile-switching pattern in `run/astrodashctl:16-48` for the case-per-profile shape.
+- The existing `environment:` list style in `docker/docker-compose.dev.yaml:36-39` for the YAML entry.
+- The parent brainstorm's plan (`docs/plans/2026-06-25-001-feat-version-source-of-truth-plan.md`) for how the Helm chart passes `APP_VERSION` on the pod's web container — this unit is the docker-compose analog.
+
+**Test scenarios (manual verification, matching origin AE1–AE5):**
+- Covers AE1: from a clean checkout with `git describe --tags --always` returning a value like `dev2-v1.1.0-3-gabc1234`, run `run/astrodashctl full_dev up`. `curl http://localhost:4000/` (or the exposed dev URL) and confirm the footer shows `// dev2-v1.1.0-3-gabc1234` and the release link href points at `.../releases/tag/dev2-v1.1.0-3-gabc1234`.
+- Covers AE2: run `APP_VERSION=custom-value run/astrodashctl full_dev up`. Confirm the footer shows `custom-value`.
+- Covers AE3: run `run/astrodashctl full_dev up` in an environment where `git describe` fails (e.g. `PATH=/tmp run/astrodashctl full_dev up` to simulate git-not-found). Confirm the footer shows `local`.
+- Covers AE4: run `run/astrodashctl full_prod up` (or `ci up`). Confirm the footer shows `local`.
+- Covers AE5: run `docker compose --file docker/docker-compose.yml --file docker/docker-compose.dev.yaml --profile full_dev up` directly with no `APP_VERSION` in the shell env. Confirm the footer shows `local`.
+
+**Verification:**
+- Run `shellcheck run/astrodashctl` and confirm no new warnings.
+- Run the existing Django test suite (`docker compose exec app python manage.py test` or the project's canonical test command) inside the container — 34/34 tests should still pass; no code paths changed.
+- Perform the manual footer inspections above.
+
+---
+
+### U2. Developer docs mention
+
+**Goal:** Give a developer running `astrodashctl full_dev up` a discoverable explanation of what the footer will show and how to override it.
+
+**Requirements:** No direct R-ID — resolves origin Outstanding Question 2 (docs discovery vs. startup-log alone).
+
+**Dependencies:** U1 (the mechanism must exist for the docs to describe it truthfully).
+
+**Files:**
+- `docs/developer/getting-started.md` (modify — add a short section)
+
+**Approach:**
+
+Add a short section (paragraph or two, plus a bulleted "how to override" line) explaining:
+- In local dev, the footer displays the output of `git describe --tags --always` computed by `astrodashctl` at up-time.
+- The value is a snapshot — new commits after `up` don't refresh the footer until the next `astrodashctl full_dev up`. `--dirty` is intentionally omitted (the dev overlay bind-mounts `../app:/app`, so the working tree diverges from the snapshot the moment code is edited; a stale `-dirty` suffix would report false state).
+- Override for testing a specific string: `APP_VERSION=some-value run/astrodashctl full_dev up`.
+- The value also appears in `/healthz` and the startup log line emitted by `AstroDashConfig.ready()`.
+
+Place the section near existing content that describes the docker-compose dev flow. If `getting-started.md` has a "Running the dev stack" or similar heading, insert this as a subsection. If no obvious anchor exists, add a new heading like `### The footer version string in local dev` near the docker-compose invocation instructions.
+
+Cross-link to `docs/operator-runbook.md` (the parent brainstorm's operator-side counterpart) so a reader sees both halves of the story.
+
+**Patterns to follow:**
+- The parent brainstorm's `docs/operator-runbook.md` addition for the K8s side — same tone, same shape.
+- The existing prose voice in `docs/developer/getting-started.md`.
+
+**Test expectation:** none — this is pure documentation; verification is a manual reading pass.
+
+**Verification:**
+- The added text renders cleanly in `docs/developer/getting-started.md` (no broken markdown).
+- The explanation matches the mechanism U1 implements — no drift.
+
+---
+
+### U3. Django test guarding the compose YAML
+
+**Goal:** Prevent regression on R4 — someone accidentally removes or edits the `APP_VERSION=${APP_VERSION:-local}` line in `docker/docker-compose.dev.yaml` without noticing.
+
+**Requirements:** Regression guard on R4.
+
+**Dependencies:** U1 (the guarded line must be present for the test to pass).
+
+**Files:**
+- `app/astrodash/tests/test_compose_app_version.py` (create)
+
+**Approach:**
+
+Add a `SimpleTestCase` that reads `docker/docker-compose.dev.yaml` from disk and asserts the app-service `environment:` block includes an `APP_VERSION` entry whose value is exactly `${APP_VERSION:-local}` (or the equivalent unquoted form). The assertion is a regex against the file text — no YAML parsing needed for the guard to be effective, and pattern-matching keeps the test resilient to trivial reformatting.
+
+Path resolution: climb from the test file to the repo root via `Path(__file__).resolve().parents[N]`, then join `docker/docker-compose.dev.yaml`. Mirror the path-climbing shape used by `test_no_version_literals.py`.
+
+Include two positive scenarios (the literal form present with `"` quotes and with `'` quotes both pass — the exact quoting isn't the point) and one negative scenario (a synthetic YAML fragment missing the line fails). The negative scenario runs against an in-memory string, not against a mutated file — the test never edits the real compose file.
+
+**Patterns to follow:**
+- `app/astrodash/tests/test_no_version_literals.py` — the existing regression guard from the parent brainstorm. This unit mirrors its shape (regex against file text, no external YAML parser dependency, both a live-filesystem scan and unit tests of the pattern itself).
+- Google-style docstrings on new test methods (per user CLAUDE.md).
+- Black formatting on the new file (per user CLAUDE.md).
+
+**Test scenarios:**
+- Happy path: the live `docker/docker-compose.dev.yaml` file contains a line matching `APP_VERSION=${APP_VERSION:-local}` (in either quoted form). Assertion succeeds.
+- Pattern positive: an in-memory YAML fragment with `- "APP_VERSION=${APP_VERSION:-local}"` matches the guard's regex.
+- Pattern positive: the same fragment with single quotes matches.
+- Pattern negative: an in-memory YAML fragment with the `APP_VERSION` line removed does NOT match the guard's regex.
+- Pattern negative: an in-memory YAML fragment with `APP_VERSION=` alone (missing the fallback) does NOT match.
+
+**Verification:**
+- The new test file passes when the compose YAML is correct.
+- Delete the `APP_VERSION=${APP_VERSION:-local}` line from `docker/docker-compose.dev.yaml` locally, re-run the test, confirm it fails, then restore the line. (Done manually as a one-time sanity check; do not commit the deletion.)
+- Run the full Django test suite; existing 34 tests plus the new tests all pass.
+- Run `black app/astrodash/tests/test_compose_app_version.py` and confirm no reformatting is applied.
+
+---
+
+## Scope Boundaries
+
+Carried from origin, unchanged:
+
+- **Container-side computation (Approach B) is deferred.** Bind-mounting `.git` and installing `git` in the dev image would let raw `docker compose up` outside `astrodashctl` still get a meaningful footer; not worth the image dep and `.git` mount while `astrodashctl` is canonical.
+- **`full_prod`, `slim_prod`, `ci`, and `docs` profiles keep the `local` placeholder.** Different intent; CI shallow-checkout noise.
+- **Refreshing the footer without a full down/up cycle is out of scope.** `docker compose restart app` does not re-interpolate.
+- **The release-link footer target is unchanged.** Still 404s for git-describe values; consistent with today's `local` behavior.
+- **Tag-naming and `git describe` flag variations are not in scope.** `--tags --always` is the choice; alternate shapes not explored.
+- **Helm/Kubernetes deploy path is unchanged.** Parallel dev-side mechanism.
+
+### Deferred to Follow-Up Work
+
+- **`env/.env.dev` var-precedence documentation.** Feasibility review flagged: if a future contributor sets `APP_VERSION` in `env/.env.dev`, astrodashctl's shell export wins during compose interpolation. Currently benign (`.env.dev` is empty), but worth a docs mention if `.env.dev` grows. Skip for now.
+- **Multi-worktree AE.** Scope-guardian and adversarial noted the motivating multi-worktree scenario isn't exercised by an explicit AE. The mechanism structurally covers it, but a demonstrating AE would close the loop between Problem Frame and Acceptance Examples. Follow-up.
+- **`docker compose build --build-arg APP_VERSION=...` middle path.** Adversarial noted this alternative was not enumerated. Not adopted, but worth naming and dismissing in a future doc pass.
+- **Visual distinction for dev-profile footer.** Product-lens deferred question: should the dev footer visually distinguish itself from a release (color, prefix, tooltip)? Not part of this mechanism.
+
+---
+
+## Risks & Dependencies
+
+- **Bash `set -e` interaction.** `run/astrodashctl` runs under `set -e` (line 3). The `git describe ... 2>/dev/null || echo local` pattern is safe under `set -e` — the OR-list succeeds via the fallback whenever git fails. Same guarantee applies inside a `$(...)` substitution. Verified in the origin's feasibility review.
+- **Compose interpolation timing.** `docker compose ... up` interpolates YAML using the host environment at invocation time. `docker compose restart <svc>` does NOT re-interpolate; a new value takes effect only on the next `up`. Behavior is documented as the "snapshot at up-time" Key Decision.
+- **Assumption: `git` is on the host PATH when developers run astrodashctl.** Standard developer machine assumption; the fallback covers the failure mode if the assumption breaks.
+
+---
+
+## Open Questions
+
+None blocking. Both origin outstanding questions resolved:
+
+- **Bash smoke test / shellcheck coverage** — resolved: no dedicated bash test harness; shellcheck-clean is the bar. U3 provides the meaningful regression guard on the more likely mutation vector (compose YAML edit).
+- **Docs mention or startup log sufficient?** — resolved: add the docs mention (U2). The startup log alone isn't discoverable pre-launch; a developer reading getting-started.md before their first `astrodashctl full_dev up` benefits from a heads-up.
+
+---
+
+## Sources & Research
+
+- `docs/brainstorms/2026-07-01-local-dev-app-version-requirements.md` — origin doc; all R-IDs and AE-IDs referenced above trace here.
+- `docs/brainstorms/2026-06-25-version-source-of-truth-requirements.md` — parent brainstorm; establishes the `local` fallback contract (R1) and 404-link affordance (AE3) this plan preserves.
+- `docs/plans/2026-06-25-001-feat-version-source-of-truth-plan.md` — parent plan; U3 (Helm chart env var) is the K8s analog of U1's compose-side edit here.
+- `run/astrodashctl:5,16-48,69-76` — repo-root `cd`, profile switching, and `docker compose up` invocation site.
+- `docker/docker-compose.dev.yaml:36-42` — app service `environment:` block; insertion point for the compose edit.
+- `app/astrodash/tests/test_no_version_literals.py` — the pattern U3 mirrors (regex-against-file guard with positive/negative pattern tests).
+- `app/astrodash_project/settings.py:16-33` — `resolve_app_version()`, unchanged by this plan.
+- `docs/operator-runbook.md` — the operator-side counterpart from the parent work; U2 is its developer-side symmetric addition.

--- a/run/astrodashctl
+++ b/run/astrodashctl
@@ -66,6 +66,17 @@ if [[ "${COMPOSE_FILE}x" != "x" ]]; then
   COMPOSE_FILES="${COMPOSE_FILES} --file docker/${COMPOSE_FILE}"
 fi
 
+# For dev profiles, derive APP_VERSION from git describe so the footer,
+# /healthz, and startup log show what's actually loaded. `${APP_VERSION:-...}`
+# preserves a pre-set value; the inner fallback catches every git-side failure
+# (git binary missing, `.git` missing, no reachable commit).
+case "$PROFILE" in
+  "full_dev" | "slim_dev")
+    APP_VERSION="${APP_VERSION:-$(git describe --tags --always 2>/dev/null || echo local)}"
+    export APP_VERSION
+    ;;
+esac
+
 case "$ACTION" in
   "up")
     set -x


### PR DESCRIPTION
## Summary

  Extends the APP_VERSION source-of-truth mechanism to the local docker-compose
  dev flow. Previously the footer always read `local` in local development,
  because nothing set `APP_VERSION` for the compose stack. Now, on the `full_dev`
  and `slim_dev` profiles, `run/astrodashctl` computes `git describe --tags
  --always` on the host and exports it, and `docker/docker-compose.dev.yaml` reads
  it into the app container. The footer, `/healthz` payload, and startup log show
  the git-describe string instead of the `local` placeholder.

  The motivating case: developers here run multiple checkouts, worktrees, and
  branches through the same stack (`.worktrees/feat-<x>` alongside `main`), and
  the footer was silent about which one was loaded. It now names the commit the
  stack was launched from.

  > **Depends on:** the Django-side source-of-truth work in
  > `feat/app-version-from-image-tag` (the `resolve_app_version()` resolver that
  > reads the env var). This branch is based on it. Merge that first, or target
  > this PR at that branch.

  ## What changed

  - **`run/astrodashctl`**: on `full_dev` and `slim_dev`, compute
    `APP_VERSION="${APP_VERSION:-$(git describe --tags --always 2>/dev/null ||
    echo local)}"` and export it before invoking `docker compose ... up`. The
    parameter-expansion form preserves a pre-set `APP_VERSION`, and the inner
    fallback catches every git-side failure (git binary missing, `.git` missing,
    no reachable commit). Non-dev profiles are untouched.
  - **`docker/docker-compose.dev.yaml`**: the app service `environment:` block
    reads `APP_VERSION=${APP_VERSION:-local}`, passing the host value through with
    `local` as the compose-default for launches that bypass `astrodashctl`.
  - **`docs/developer/getting-started.md`**: a short section explaining what the
    footer shows in local dev, why `--dirty` is omitted, and how to override.
  - **`app/astrodash/tests/test_compose_app_version.py`**: a regression guard that
    scans the compose file for the `APP_VERSION` entry, so a future edit cannot
    silently drop the line and revert the footer to `local`.

  ## Design decisions

  - **Host-side git describe, mirroring the Helm shape.** The docker-compose flow
    becomes structurally symmetric with the deployed path: an external
    orchestrator sets the env, the container reads it. No new container binary, no
    `.git` bind-mount. Reading git on the host at up-time is the docker-compose
    analog of the Helm chart passing `.Values.image.tag`.
  - **`--dirty` intentionally omitted.** The dev overlay bind-mounts `app/` into
    the container, so running code diverges from the snapshotted working tree the
    moment anyone edits after `up`. A frozen `-dirty` (or non-dirty) suffix would
    report false state with authoritative styling. The tag plus short-commit still
    discriminates worktrees, which is what the use case needs.
  - **Snapshot at up-time, not live per request.** A commit made after `up` does
    not refresh the footer until the next `up` (`docker compose restart app` alone
    does not re-interpolate). Accepted: the value answers "which checkout brought
    this stack up," and refreshing is a re-run away.
  - **Dev profiles only.** `full_prod`, `slim_prod`, `ci`, and `docs` keep `local`.
    Prod compose profiles simulate a different intent, and CI checkouts are often
    shallow or detached and would produce noisy output.

  ## Testing

  - The regression guard runs a live-filesystem scan (compose file must carry the
    `APP_VERSION` entry) plus positive/negative pattern tests, so a future
    weakening of the guard's regex cannot silently disable it. The live scan uses
    `skipUnless` to degrade gracefully inside the dev container, where only `app/`
    is bind-mounted and `docker/` is not reachable.
  - Full Django suite: 38 tests pass (1 skipped by design, the live scan inside
    the container).
  - Verified end to end: with the stack up via `astrodashctl full_dev up`, the
    footer showed `dev2-v1.1.0-4-g0fa884f` and the release link href pointed at
    the same string.

  ## Post-Deploy Monitoring & Validation

  No production or runtime impact: this changes the local docker-compose developer
  flow only. The deployed Kubernetes path is unchanged. Validation is the manual
  footer check above, run locally.