### PR TITLE
fix: update footer NSF disclaimer wording

### DIFF
--- a/app/astrodash/templates/astrodash/base_site.html
+++ b/app/astrodash/templates/astrodash/base_site.html
@@ -190,7 +190,7 @@
         </span>
       </span>
       <div class="text-muted" style="font-size: 0.75rem; margin-top: 6px;">
-        This project is supported by National Science Foundation grants <a href="https://www.nsf.gov/awardsearch/showAward?AWD_ID=1841625">OAC-1841625</a>, <a href="https://www.nsf.gov/awardsearch/showAward?AWD_ID=1934752">OAC-1934752</a>, <a href="https://www.nsf.gov/awardsearch/showAward?AWD_ID=2311355&HistoricalAwards=false">OAC-2311355</a>, <a href="https://www.nsf.gov/awardsearch/showAward?AWD_ID=2432428">AST-2432428</a>. Any opinions, findings, conclusions or recommendations expressed in this material are those of the developers and do not necessarily reflect the views of the National Science Foundation.
+        This project is supported by National Science Foundation grants <a href="https://www.nsf.gov/awardsearch/showAward?AWD_ID=1841625">OAC-1841625</a>, <a href="https://www.nsf.gov/awardsearch/showAward?AWD_ID=1934752">OAC-1934752</a>, <a href="https://www.nsf.gov/awardsearch/showAward?AWD_ID=2311355&HistoricalAwards=false">OAC-2311355</a>, <a href="https://www.nsf.gov/awardsearch/showAward?AWD_ID=2432428">AST-2432428</a>. Any opinions, findings and conclusions or recommendations expressed in this material are those of the author(s) and do not necessarily reflect the views of the National Science Foundation.
       </div>
     </div>
   </footer>


### PR DESCRIPTION
Addresses scimma/astrodash#51.

Update the footer NSF acknowledgement to the standard disclaimer prose:

- "findings and conclusions" (was "findings, conclusions")
- attribute the views to "the author(s)" (was "the developers")

The grant-support sentence and the grant links are unchanged. This is a
copy-only change to a single Django template; no logic or behavior is
affected.