### PR TITLE
docs: capture release-workflow learnings in solutions store

### DIFF
--- a/docs/solutions/workflow-issues/astrodash-tag-driven-release-and-deploy-flow.md
+++ b/docs/solutions/workflow-issues/astrodash-tag-driven-release-and-deploy-flow.md
@@ -1,0 +1,128 @@
+---
+title: "AstroDash tag-driven release and deploy flow (build tag -> gitops image.tag -> ArgoCD)"
+date: 2026-08-10
+category: workflow-issues
+module: Release / CI-CD / GitOps deploy
+problem_type: workflow_issue
+component: development_workflow
+severity: medium
+applies_when:
+  - "Cutting a DEV test build or a PROD release of AstroDash"
+  - "A code change is merged upstream and needs to reach DEV or PROD"
+  - "Deciding which tag name and which gitops values file to touch for a rollout"
+tags: [release, deploy, argocd, gitops, docker-tag, ci-cd, versioning]
+---
+
+# AstroDash tag-driven release and deploy flow (build tag -> gitops image.tag -> ArgoCD)
+
+## Context
+
+AstroDash has two decoupled halves that together make a deploy: a **git tag on
+`upstream` builds an image**, and a **gitops `image.tag` bump drives the
+rollout**. They are separate actions in separate repos, and conflating them (or
+doing them in the wrong order) leaves either an image nobody is running or a
+values file pointing at an image that does not exist yet. This documents the
+full round trip, captured while shipping `v1.1.0` (and its `dev4-v1.1.0` and
+`dev5-v1.1.0` test builds).
+
+## Guidance
+
+**Two axes, two tag shapes.** `.github/workflows/docker_image_workflow.yml`
+fires only on tags matching two patterns
+(`.github/workflows/docker_image_workflow.yml:5-7`):
+
+- `dev[0-9]-v<X.Y.Z>` -> builds `registry.gitlab.com/ncsa-caps-rse/astrodash-k8s-gitops:<tag>` **and** `:dev` (`docker_image_workflow.yml:33`)
+- `v<X.Y.Z>` -> builds `...:<tag>` **and** `:latest` (`docker_image_workflow.yml:30`)
+
+Tag-shape convention (match it): **DEV tags are lightweight**, **release tags
+are annotated** with message `"vX.Y.Z SCiMMA Astrodash"` (mirrors the existing
+`v1.0.0` tag).
+
+**Push tags to `upstream`, not `origin`.** The build only runs where the GitLab
+registry secrets live -- the canonical `scimma/astrodash` repo. Prior dev/release
+tags exist on `upstream` and nowhere on `origin`; a tag pushed to `origin` builds
+nothing.
+
+**The rollout is a one-line gitops edit on `main`.** The deploy repo is
+`../astrodash-k8s-gitops`; both ArgoCD apps track `targetRevision: HEAD` (= the
+default branch `main`) with `path: apps/astrodash`
+(`astrodash-k8s-gitops/argocd-apps/astrodash-dev.yaml:10-11`). Bump the
+environment's `image.tag` (paths below are in the gitops repo, not this one):
+
+- DEV -> `astrodash-k8s-gitops/apps/astrodash/values-dev.yaml` (`pullPolicy: Always`)
+- PROD -> `astrodash-k8s-gitops/apps/astrodash/values-prod.yaml` (`pullPolicy: IfNotPresent`)
+
+Commit the bump **directly to `main`** (the established convention, e.g. commit
+`chore: update dev image tag to dev5-v1.1.0`) and push. ArgoCD reconciles main
+and rolls the pods. Note the gitops remote is **GitLab over SSH**, which the VM
+cannot push -- the maintainer pushes the gitops commit from the host.
+
+**End-to-end order (DEV shown; PROD is identical with the `v<X.Y.Z>` tag and
+`values-prod.yaml`):**
+
+1. `git tag dev5-v1.1.0 <commit>` (lightweight) -> `git push upstream dev5-v1.1.0`
+2. Wait for the Actions build to go green **before** the gitops bump, or ArgoCD
+   pulls a tag that is not in the registry yet
+   (`gh run watch <id> --repo scimma/astrodash`)
+3. In gitops on `main`: `values-dev.yaml` `tag:` -> `dev5-v1.1.0`, commit, push
+4. Verify the rollout (below)
+
+**Verify via the footer, not `/healthz`.** `settings.APP_VERSION` resolves from
+the `APP_VERSION` env var, which the Helm chart sets from `.Values.image.tag`,
+falling back to the literal `local` (`app/astrodash_project/settings.py:33`).
+The rendered surface is the footer, which links to
+`releases/tag/{app_version}` (`base_site.html:189`). Despite references to a
+`/healthz` payload in comments, **no `/healthz` route is currently registered**
+-- that path 404s. Scrape the footer instead:
+
+```bash
+curl -s https://astrodash-dev.scimma.org/astrodash/ \
+  | grep -oE 'releases/tag/[^"]+' | head -1   # -> releases/tag/dev5-v1.1.0
+```
+
+Expect a brief window during the rollout where the pod is restarting and the
+scrape returns nothing before the new tag appears.
+
+## Why This Matters
+
+The build axis and the deploy axis are independent, so the failure modes are
+silent: tag `origin` and nothing builds; bump the gitops tag before the build
+finishes and ArgoCD wedges on an ImagePullBackOff; edit the wrong values file
+and the other environment moves. Knowing that a deploy is exactly "tag upstream
+-> confirm image -> bump `image.tag` on gitops main -> ArgoCD reconciles"
+collapses a multi-repo, multi-actor process into four unambiguous steps, and
+makes the DEV-then-PROD promotion (same commit, `dev[N]-v1.1.0` then `v1.1.0`)
+routine.
+
+## When to Apply
+
+- Promoting a merged change to DEV for testing, then to PROD
+- Any time the running version needs to change (the footer version is the check)
+- Diagnosing "I pushed a tag but nothing deployed" (wrong remote, or missing
+  gitops bump) or "ArgoCD can't pull the image" (bumped before the build was green)
+
+## Examples
+
+DEV test build:
+
+```bash
+git tag dev5-v1.1.0 6ee8595                 # lightweight dev tag
+git push upstream dev5-v1.1.0               # builds :dev5-v1.1.0 and :dev
+# ... build green ...
+# gitops main: values-dev.yaml  tag: dev4-v1.1.0 -> dev5-v1.1.0
+git commit -am "chore: update dev image tag to dev5-v1.1.0" && git push origin main
+```
+
+PROD release (same commit, promoted after DEV testing):
+
+```bash
+git tag -a v1.1.0 -m "v1.1.0 SCiMMA Astrodash" 6ee8595   # annotated release tag
+git push upstream v1.1.0                                   # builds :v1.1.0 and :latest
+# gitops main: values-prod.yaml  tag: v1.0.0 -> v1.1.0
+git commit -am "chore: update prod image tag to v1.1.0" && git push origin main
+```
+
+## Related
+- Repo CLAUDE.md "Versioning (APP_VERSION)" and "Deployment and the gitops repo" sections
+- `docs/solutions/workflow-issues/push-rejected-workflow-scope-stale-fork.md` (fork-push gotcha in the same tag/push workflow)
+- Companion gitops repo: `../astrodash-k8s-gitops` (Helm chart, per-env values, ArgoCD apps)

--- a/docs/solutions/workflow-issues/push-rejected-workflow-scope-stale-fork.md
+++ b/docs/solutions/workflow-issues/push-rejected-workflow-scope-stale-fork.md
@@ -1,0 +1,125 @@
+---
+title: "Fork push rejected for `workflow` scope when origin/main lags upstream"
+date: 2026-08-10
+category: workflow-issues
+module: Git fork workflow / GitHub Actions
+problem_type: workflow_issue
+component: development_workflow
+severity: medium
+applies_when:
+  - "Pushing a feature branch to a fork (origin) whose main is behind upstream/main"
+  - "The commit range between origin/main and the branch touches .github/workflows/"
+  - "Authenticating to GitHub with a Personal Access Token that lacks the workflow scope"
+tags: [git, github, workflow-scope, fork, personal-access-token, ci]
+---
+
+# Fork push rejected for `workflow` scope when origin/main lags upstream
+
+## Context
+
+This repo uses a fork-based workflow: `origin` is the maintainer's fork
+(`github.com/skoranda/astrodash`) and `upstream` is canonical
+(`github.com/scimma/astrodash`). Feature branches are cut from local `main`
+(kept level with `upstream/main`) and pushed to `origin` to open pull requests.
+Inside the VM, git authenticates to GitHub over HTTPS with a `GH_TOKEN`
+Personal Access Token.
+
+While preparing a one-line footer fix (issue #51), the branch push to `origin`
+was rejected outright:
+
+```
+ ! [remote rejected] fix/footer-nsf-disclaimer -> fix/footer-nsf-disclaimer
+   (refusing to allow a Personal Access Token to create or update workflow
+    `.github/workflows/docker_image_workflow.yml` without `workflow` scope)
+error: failed to push some refs to 'https://github.com/skoranda/astrodash.git'
+```
+
+The single commit on the branch touched only a Django template
+(`app/astrodash/templates/astrodash/base_site.html`) -- nothing under
+`.github/workflows/`. The rejection was confusing because the *change* had no
+workflow files in it.
+
+## Guidance
+
+The push carries every commit the target ref does not already have, not just
+the branch's own commit. When `origin/main` lags `upstream/main`, a branch cut
+from the up-to-date local `main` drags along all the intervening merged commits
+-- and if any of those touched `.github/workflows/`, GitHub's PAT
+`workflow`-scope guard rejects the **entire push**, even though your own commit
+is innocent.
+
+Diagnose by listing what the branch adds over the *remote* target and filtering
+to workflow paths:
+
+```bash
+git fetch origin
+git log --oneline origin/main..<branch>                      # full pushed range
+git log --oneline origin/main..<branch> -- .github/workflows/ # the offenders
+```
+
+If the second command prints anything, that is what trips the guard.
+
+Preferred fix -- get `origin/main` current so the branch's unique range no
+longer includes workflow commits (this repo: the maintainer pushes `origin/main`
+up to `upstream/main` from a context that has `workflow` scope):
+
+```bash
+# after origin/main is fast-forwarded to upstream/main:
+git fetch origin
+git log --oneline origin/main..<branch> -- .github/workflows/   # now empty
+git push -u origin <branch>                                       # succeeds
+```
+
+With `origin/main == upstream/main`, the branch's only unique commit is your
+own change, the pushed range contains no workflow files, and the scope guard is
+never triggered.
+
+Alternative fixes (not used here): grant the PAT the `workflow` scope, or push
+from an SSH-keyed context that is not subject to the PAT-scope guard.
+
+## Why This Matters
+
+The error names a workflow file and a missing scope, which misleads you toward
+"my change edited a workflow" or "regenerate the token" -- when the real cause
+is that the *fork's default branch is stale*. Understanding that a push is
+evaluated over the full `remote..branch` commit range (not just your commit)
+turns a baffling rejection into a one-line diagnosis, and points at the correct
+remedy: sync the fork, don't broaden the token's scope. Keeping a PAT narrow
+(no `workflow` scope) is the safer default; syncing `origin/main` preserves that
+posture instead of widening the token to work around a stale fork.
+
+## When to Apply
+
+- A `[remote rejected] ... without 'workflow' scope` push failure on a branch
+  whose own diff contains no `.github/workflows/` changes
+- Any fork whose `main` has fallen behind `upstream` and accumulated merged
+  CI/dependency (e.g. Dependabot) commits that edited workflow files
+- Before reaching for a broader token scope -- check the stale-fork cause first
+
+## Examples
+
+Before (origin/main stale -- push carries 30 commits, 10 touching workflows):
+
+```
+$ git log --oneline origin/main..fix/footer-nsf-disclaimer -- .github/workflows/
+3489fd4 Merge pull request #53 ... docker/login-action-4.5.2
+edc4bf2 Merge pull request #52 ... actions/checkout-7
+e70261a ci: add a GitHub Actions test gate on pull requests and merges
+... (7 more)
+$ git push -u origin fix/footer-nsf-disclaimer
+ ! [remote rejected] ... without `workflow` scope
+```
+
+After (origin/main fast-forwarded to upstream/main -- branch adds one commit):
+
+```
+$ git log --oneline origin/main..fix/footer-nsf-disclaimer
+357e483 fix: update footer NSF disclaimer wording
+$ git log --oneline origin/main..fix/footer-nsf-disclaimer -- .github/workflows/
+$ git push -u origin fix/footer-nsf-disclaimer
+ * [new branch]      fix/footer-nsf-disclaimer -> fix/footer-nsf-disclaimer
+```
+
+## Related
+- Repo CLAUDE.md "Git workflow" section (fork remotes, VM HTTPS + GH_TOKEN rewrite)
+- upstream issue scimma/astrodash#51 (the footer change that surfaced this)


### PR DESCRIPTION
Seeds docs/solutions/workflow-issues/ with two hard-won learnings from the
v1.1.0 release cycle, captured via ce-compound.

- push-rejected-workflow-scope-stale-fork.md: a fork push is rejected for
  missing `workflow` scope when origin/main lags upstream, because the push
  carries the full remote..branch commit range and drags in merged
  .github/workflows/ commits. The fix is to sync origin/main first, not to
  broaden the token scope.
- astrodash-tag-driven-release-and-deploy-flow.md: the two-axis release flow --
  lightweight dev[N]-vX.Y.Z vs annotated vX.Y.Z tags pushed to upstream build
  the image; a gitops image.tag bump on main drives the ArgoCD rollout. Covers
  correct ordering and footer-based verification.

Both are knowledge-track docs with YAML frontmatter and cross-reference each
other. Docs-only change; no runtime or CI impact.

Note: the companion CLAUDE.md discoverability line is gitignored in this repo
and stays local-only, so it is not part of this PR.