### PR TITLE
feat(models): let a model definition control its own public surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ Jetstream2 using ArgoCD for GitOps.
   deployments
 - [Contributing a Classifier](docs/guides/contributing-classifiers.md) — how
   to add a new ML model
+- [Serving a Gated Model](docs/admin/gated-model-access.md) — minting and
+  distributing a review link for a model that is not yet public
 
 ## Contributing
 

--- a/app/astrodash/apps.py
+++ b/app/astrodash/apps.py
@@ -21,14 +21,22 @@ class AstroDashConfig(AppConfig):
         configuration fails in the init container, rather than starting and
         serving that model without a credential prompt.
 
+        The declared-surface check runs here for the same reason: the registry's
+        import-time validation cannot see the web layer's surface map without
+        inverting the layer boundary, and without a runtime caller a surface id
+        with no presentation would surface as a broken tab rather than a
+        refused startup.
+
         Raises:
             ValueError: If a model in the registry requires a credential while
                 any part of the gate configuration is unset, blank, or left at
-                a committed default.
+                a committed default, or if a model declares an empty, unknown,
+                or classification-less result surface list.
         """
         from astrodash.config.logging import get_logger
         from astrodash.core.gate_config import gate_configuration
         from astrodash.infrastructure.ml import model_registry
+        from astrodash.surfaces import known_surface_ids
 
         get_logger(__name__).info(
             "AstroDash starting with APP_VERSION=%s", settings.APP_VERSION
@@ -37,3 +45,4 @@ class AstroDashConfig(AppConfig):
         model_registry.validate_gate_configuration(
             model_registry.MODELS, gate_configuration()
         )
+        model_registry.validate_surfaces(model_registry.MODELS, known_surface_ids())

--- a/app/astrodash/apps.py
+++ b/app/astrodash/apps.py
@@ -8,15 +8,32 @@ class AstroDashConfig(AppConfig):
     verbose_name = "AstroDash Integration"
 
     def ready(self) -> None:
-        """Announce the active ``APP_VERSION`` at app startup.
+        """Announce the active ``APP_VERSION`` and fail closed on a misconfigured gate.
 
         One INFO line at gunicorn boot so operators can confirm what's
         running from pod logs without exec'ing into the container.
         Django may call ``ready()`` more than once in some test setups;
         a duplicated log line is harmless.
+
+        The gate-configuration check runs here rather than at registry import
+        because ``ready()`` runs for the server *and* every management command:
+        a deployment whose registry contains a gated model but lacks the gate's
+        configuration fails in the init container, rather than starting and
+        serving that model without a credential prompt.
+
+        Raises:
+            ValueError: If a model in the registry requires a credential while
+                any part of the gate configuration is unset, blank, or left at
+                a committed default.
         """
         from astrodash.config.logging import get_logger
+        from astrodash.core.gate_config import gate_configuration
+        from astrodash.infrastructure.ml import model_registry
 
         get_logger(__name__).info(
             "AstroDash starting with APP_VERSION=%s", settings.APP_VERSION
+        )
+
+        model_registry.validate_gate_configuration(
+            model_registry.MODELS, gate_configuration()
         )

--- a/app/astrodash/core/gate_config.py
+++ b/app/astrodash/core/gate_config.py
@@ -1,0 +1,106 @@
+"""Deployment configuration for the gated-model access gate.
+
+A model definition can declare that running it requires a shared credential
+(see :mod:`astrodash.infrastructure.ml.model_registry`). Serving such a model
+needs three deployment-supplied values: the shared credential itself, the
+entry-link expiry window, and the key used to sign entry links. This module is
+the single place those values are read and normalized, so the startup check and
+the gate itself cannot drift apart on names or defaults.
+
+The values are read here -- in the web/core layer -- rather than in the model
+registry: nothing under ``astrodash.infrastructure`` imports Django or reads the
+environment, and the registry validator takes this configuration as an argument
+instead.
+
+Normalization is deliberately strict, because R34 requires a misconfigured
+deployment to fail closed rather than serve a gated model without a prompt:
+
+* an unset, empty, or whitespace-only value is unconfigured;
+* an expiry window that is not a positive integer is unconfigured;
+* a signing key left at the committed ``django-insecure-`` default -- the value
+  ``astrodash_project.settings`` falls back to when ``SECRET_KEY`` is unset --
+  is unconfigured, since a key published in the repository signs nothing.
+"""
+
+import os
+from typing import Dict, Optional
+
+from django.conf import settings
+
+# Environment variables and setting names carrying the gate's configuration.
+# These names appear verbatim in the startup failure message, so an operator
+# reads the missing configuration straight off the pod log.
+CREDENTIAL_ENV_VAR = "ASTRODASH_MODEL_GATE_CREDENTIAL"
+LINK_TTL_ENV_VAR = "ASTRODASH_MODEL_GATE_LINK_TTL_SECONDS"
+SIGNING_KEY_NAME = "SECRET_KEY"
+
+# Prefix of the placeholder signing key committed to the repository. Django
+# stamps generated placeholder keys with it, and a key carrying it is public.
+INSECURE_SIGNING_KEY_PREFIX = "django-insecure-"
+
+
+def _configured(value: Optional[str]) -> Optional[str]:
+    """Normalize a raw configuration value, treating blanks as unconfigured.
+
+    Args:
+        value: The raw value as read from the environment or settings.
+
+    Returns:
+        The stripped value, or ``None`` when it is unset, empty, or
+        whitespace-only.
+    """
+    if value is None:
+        return None
+    stripped = str(value).strip()
+    return stripped or None
+
+
+def _credential() -> Optional[str]:
+    """Return the configured shared credential, or ``None`` if unconfigured."""
+    return _configured(os.environ.get(CREDENTIAL_ENV_VAR))
+
+
+def _link_ttl_seconds() -> Optional[str]:
+    """Return the configured entry-link expiry window in seconds.
+
+    Returns:
+        The window as a string, or ``None`` when it is unset, blank, or not a
+        positive integer.
+    """
+    raw = _configured(os.environ.get(LINK_TTL_ENV_VAR))
+    if raw is None:
+        return None
+    try:
+        seconds = int(raw)
+    except ValueError:
+        return None
+    return raw if seconds > 0 else None
+
+
+def _signing_key() -> Optional[str]:
+    """Return the configured signing key, or ``None`` if unconfigured.
+
+    Returns:
+        The key from ``settings.SECRET_KEY``, or ``None`` when it is blank or
+        still the committed ``django-insecure-`` placeholder.
+    """
+    key = _configured(getattr(settings, SIGNING_KEY_NAME, None))
+    if key is None or key.startswith(INSECURE_SIGNING_KEY_PREFIX):
+        return None
+    return key
+
+
+def gate_configuration() -> Dict[str, Optional[str]]:
+    """Read the gate's deployment configuration, normalized.
+
+    Returns:
+        A mapping of configuration name to its normalized value, with ``None``
+        for every value that is unset, blank, or left at a committed default.
+        The keys are the names an operator sets, so a validator can name the
+        missing configuration back to them.
+    """
+    return {
+        CREDENTIAL_ENV_VAR: _credential(),
+        LINK_TTL_ENV_VAR: _link_ttl_seconds(),
+        SIGNING_KEY_NAME: _signing_key(),
+    }

--- a/app/astrodash/core/gate_config.py
+++ b/app/astrodash/core/gate_config.py
@@ -34,6 +34,13 @@ CREDENTIAL_ENV_VAR = "ASTRODASH_MODEL_GATE_CREDENTIAL"
 LINK_TTL_ENV_VAR = "ASTRODASH_MODEL_GATE_LINK_TTL_SECONDS"
 SIGNING_KEY_NAME = "SECRET_KEY"
 
+# Base URL entry links are minted against. It is deliberately *not* part of
+# :func:`gate_configuration`, and so not part of the startup fail-closed check:
+# a deployment with no link host still serves an already-minted link correctly,
+# and only the operator minting a new one needs it. The app sits behind a proxy,
+# so the host is configured rather than inferred from a request.
+LINK_BASE_URL_ENV_VAR = "ASTRODASH_MODEL_GATE_LINK_BASE_URL"
+
 # Prefix of the placeholder signing key committed to the repository. Django
 # stamps generated placeholder keys with it, and a key carrying it is public.
 INSECURE_SIGNING_KEY_PREFIX = "django-insecure-"
@@ -88,6 +95,18 @@ def _signing_key() -> Optional[str]:
     if key is None or key.startswith(INSECURE_SIGNING_KEY_PREFIX):
         return None
     return key
+
+
+def link_base_url() -> Optional[str]:
+    """Return the base URL entry links are minted against.
+
+    Returns:
+        The configured base URL with any trailing slash removed, or ``None``
+        when it is unset, empty, or whitespace-only. Only the mint command
+        needs it, so an unconfigured value is not a startup failure.
+    """
+    base = _configured(os.environ.get(LINK_BASE_URL_ENV_VAR))
+    return base.rstrip("/") if base else None
 
 
 def gate_configuration() -> Dict[str, Optional[str]]:

--- a/app/astrodash/core/model_access.py
+++ b/app/astrodash/core/model_access.py
@@ -32,9 +32,14 @@ Three properties are load-bearing and each is easy to get subtly wrong:
 import hmac
 import time
 from dataclasses import dataclass
+from functools import wraps
 from typing import Optional
 
+from django.contrib import messages
 from django.core import signing
+from django.http import HttpResponseRedirect, JsonResponse
+from django.shortcuts import render
+from django.urls import reverse
 
 from astrodash.core.gate_config import (
     CREDENTIAL_ENV_VAR,
@@ -42,6 +47,8 @@ from astrodash.core.gate_config import (
     SIGNING_KEY_NAME,
     gate_configuration,
 )
+from astrodash.infrastructure.ml.model_registry import get_definition
+from astrodash.surfaces import offers_route
 
 # Salt distinct to this purpose, so a token minted here cannot be replayed
 # against any other signed value the project produces.
@@ -307,3 +314,177 @@ def live_scope_model_id(session) -> Optional[str]:
     if scope_expired(session):
         return None
     return scope_model_id(session)
+
+
+def effective_model_id(session) -> Optional[str]:
+    """Return the model a request will actually run.
+
+    The scope wins over a session selection (KTD10): a scoped visitor runs the
+    scoped model whatever else the session -- or the submitted form -- says.
+
+    Args:
+        session: The request's session.
+
+    Returns:
+        The scoped model id while a live scope exists, otherwise the session's
+        model selection, otherwise ``None``.
+    """
+    return live_scope_model_id(session) or session.get("selected_model_type")
+
+
+# Copy for the two page-level refusals. The lapse case may name that the window
+# ended, because its visitor already knows which model they were using; the cold
+# case must not, because its visitor may not.
+SCOPE_LAPSED_HEADING = "This review window has ended"
+SCOPE_LAPSED_MESSAGE = (
+    "The access link that opened this session has expired, so the session has "
+    "ended and everything it produced has been discarded. If you still need "
+    "access, ask whoever sent you the link for a new one."
+)
+
+# Refusal shown when a surface is requested for a model that does not declare
+# it. Unchanged from the guard this decorator absorbed.
+SURFACE_NOT_OFFERED_MESSAGE = "This result surface is not offered for this model."
+
+# Refusal shown when a gated model is reached without a scope: it is reachable
+# only through an entry link, so the visitor is returned to the public picker.
+GATED_WITHOUT_SCOPE_MESSAGE = (
+    "That model is not available. Please choose a model to continue."
+)
+
+
+# Why a guarded request was refused. The gate evaluates in a fixed order --
+# deadline, scope present, model selectable, surface declared -- because the
+# order decides what a refused visitor learns.
+REFUSED_SCOPE_LAPSED = "scope_lapsed"
+REFUSED_GATED_WITHOUT_SCOPE = "gated_without_scope"
+REFUSED_SURFACE_NOT_OFFERED = "surface_not_offered"
+
+
+def _refusal_for(request, reason, as_json):
+    """Build the response for a refused request.
+
+    Args:
+        request: The current request.
+        reason: One of the ``REFUSED_*`` reasons.
+        as_json: Whether the caller is a JSON route.
+
+    Returns:
+        HttpResponse: The refusal.
+    """
+    if reason == REFUSED_SCOPE_LAPSED:
+        if as_json:
+            return JsonResponse({"error": SCOPE_LAPSED_MESSAGE}, status=403)
+        return render(
+            request,
+            "astrodash/model_gate_refused.html",
+            {
+                "refusal_heading": SCOPE_LAPSED_HEADING,
+                "refusal_message": SCOPE_LAPSED_MESSAGE,
+            },
+            status=403,
+        )
+
+    if reason == REFUSED_GATED_WITHOUT_SCOPE:
+        if as_json:
+            return JsonResponse({"error": SURFACE_NOT_OFFERED_MESSAGE}, status=403)
+        if request.path == reverse("astrodash:classify"):
+            # The classification page is the one an ordinary visitor can land on
+            # with a stale selection, so it is returned to the picker rather
+            # than shown an error page.
+            messages.error(request, GATED_WITHOUT_SCOPE_MESSAGE)
+            return HttpResponseRedirect(
+                reverse("astrodash:model_selection") + "?action=classify"
+            )
+        return render(
+            request,
+            "astrodash/model_gate_refused.html",
+            {"refusal_heading": None, "refusal_message": None},
+            status=403,
+        )
+
+    if as_json:
+        return JsonResponse({"error": SURFACE_NOT_OFFERED_MESSAGE}, status=403)
+    return render(
+        request,
+        "astrodash/model_gate_refused.html",
+        {
+            "refusal_heading": "This view is not available",
+            "refusal_message": SURFACE_NOT_OFFERED_MESSAGE,
+        },
+        status=403,
+    )
+
+
+def evaluate_access(session, model_id, route_name):
+    """Decide whether a guarded request may proceed.
+
+    Checks run in a fixed order -- deadline, then scope presence, then whether
+    the model is reachable at all, then whether it declares the surface -- so a
+    refusal cannot leak by ordering.
+
+    Args:
+        session: The request's session. A lapsed scope is torn down here, so
+            nothing it produced stays reachable.
+        model_id: The model that authorizes this request (see
+            :func:`astrodash.surfaces.declared_surfaces`).
+        route_name: The supporting route's name, or ``None`` for the
+            classification view itself, which owns no supporting route.
+
+    Returns:
+        One of the ``REFUSED_*`` reasons, or ``None`` when the request may
+        proceed.
+    """
+    if scope_model_id(session) and scope_expired(session):
+        end_scope(session)
+        return REFUSED_SCOPE_LAPSED
+
+    if live_scope_model_id(session) is None:
+        definition = get_definition(model_id) if model_id else None
+        if definition is not None and definition.requires_credential:
+            return REFUSED_GATED_WITHOUT_SCOPE
+
+    if route_name and not offers_route(model_id, route_name):
+        return REFUSED_SURFACE_NOT_OFFERED
+
+    return None
+
+
+def model_access_required(route_name=None, *, from_classified=False, as_json=False):
+    """Guard a view that can run a model, consulting the scope on every request.
+
+    A decorator rather than middleware (KTD1): the only hand-rolled gate this
+    codebase has is the interim API-writes decorator, there is no
+    project-authored Django middleware at all, and Django reserves middleware
+    for whole-app defaults. Because a decorator is opt-in by nature, a guard
+    test walks every route the surface map declares and asserts this is applied.
+
+    Args:
+        route_name: The name of the supporting route being guarded, or ``None``
+            for the classification view itself.
+        from_classified: Whether the route authorizes from the *classified*
+            model rather than the selected one (KTD5). True only for a route
+            that consumes a classification artifact; a route serving a
+            model-agnostic payload authorizes from the selection, so it stays
+            browsable before any classification, exactly as today.
+        as_json: Whether refusals should be JSON rather than a rendered page.
+
+    Returns:
+        The view decorator.
+    """
+
+    def decorate(view_func):
+        @wraps(view_func)
+        def wrapper(request, *args, **kwargs):
+            if from_classified:
+                model_id = request.session.get("classify_model_type")
+            else:
+                model_id = effective_model_id(request.session)
+            reason = evaluate_access(request.session, model_id, route_name)
+            if reason is not None:
+                return _refusal_for(request, reason, as_json)
+            return view_func(request, *args, **kwargs)
+
+        return wrapper
+
+    return decorate

--- a/app/astrodash/core/model_access.py
+++ b/app/astrodash/core/model_access.py
@@ -416,6 +416,110 @@ def _refusal_for(request, reason, as_json):
     )
 
 
+# Shown when a scoped session asks for a flow the scope does not admit. It
+# points at the end action rather than simply refusing, because the visitor's
+# way out is to end the scope, not to navigate away.
+SCOPED_FLOW_UNAVAILABLE_MESSAGE = (
+    "This session is limited to one model, so only classification is "
+    "available. End the session to return to the model picker."
+)
+
+# Shown when a session's stored model is no longer one a visitor may select.
+MODEL_NO_LONGER_SELECTABLE_MESSAGE = (
+    "The model this session had selected is no longer available. Please choose "
+    "a model to continue."
+)
+
+
+def clear_selection(session) -> None:
+    """Drop a model selection the session may no longer use.
+
+    Args:
+        session: The request's session.
+    """
+    for key in SELECTION_SESSION_KEYS:
+        session.pop(key, None)
+    session.modified = True
+
+
+def scoped_flow_refusal(request, action="classify"):
+    """Refuse a flow a scoped session may not enter, or let it through.
+
+    A scope reaches classification only, so the batch flow and the selection
+    page -- both its rendered page and its POST handler -- are refused for a
+    scoped visitor and pointed back at the classification page, where the
+    explicit end action lives.
+
+    Args:
+        request: The current request.
+        action: The selection action this flow belongs to, used when a lapsed
+            scope has to send the visitor back to the picker.
+
+    Returns:
+        HttpResponse: The refusal, or ``None`` when the request may proceed.
+    """
+    if scope_model_id(request.session) and scope_expired(request.session):
+        end_scope(request.session)
+        return _refusal_for(request, REFUSED_SCOPE_LAPSED, as_json=False)
+
+    if live_scope_model_id(request.session) is not None:
+        messages.error(request, SCOPED_FLOW_UNAVAILABLE_MESSAGE)
+        return HttpResponseRedirect(reverse("astrodash:classify"))
+
+    return None
+
+
+def revalidate_session_model(request, action="classify"):
+    """Re-check the session's model on entry to a flow, per R35.
+
+    Two things can have changed under a session since it last ran: its model
+    may have been published (dissolving a scope that no longer has anything to
+    guard), or it may have become gated, unlisted, or retired (making a public
+    session's selection unusable). Both are settled here, on entry, rather than
+    being discovered halfway through a classification.
+
+    Only ids the registry resolves are revalidated: a user-uploaded selection
+    passes through untouched, or every uploaded-model visitor would be bounced
+    to the picker.
+
+    Args:
+        request: The current request.
+        action: The selection action to return to, ``"classify"`` or
+            ``"batch"``.
+
+    Returns:
+        HttpResponse: A redirect to the selection page when the session's model
+        is no longer selectable, or ``None`` when the request may proceed.
+    """
+    scoped = scope_model_id(request.session)
+    if scoped:
+        definition = get_definition(scoped)
+        if definition is not None and not definition.requires_credential:
+            # Published: there is nothing left to scope, so the scope dissolves
+            # into an ordinary selection of the same model.
+            end_scope(request.session)
+            request.session["selected_model_type"] = scoped
+        return None
+
+    selected = request.session.get("selected_model_type")
+    definition = get_definition(selected) if selected else None
+    if definition is None:
+        return None
+
+    if (
+        definition.requires_credential
+        or not definition.listed
+        or not definition.is_active
+    ):
+        clear_selection(request.session)
+        messages.error(request, MODEL_NO_LONGER_SELECTABLE_MESSAGE)
+        return HttpResponseRedirect(
+            reverse("astrodash:model_selection") + f"?action={action}"
+        )
+
+    return None
+
+
 def evaluate_access(session, model_id, route_name):
     """Decide whether a guarded request may proceed.
 
@@ -482,6 +586,11 @@ def model_access_required(route_name=None, *, from_classified=False, as_json=Fal
                 model_id = effective_model_id(request.session)
             reason = evaluate_access(request.session, model_id, route_name)
             if reason is not None:
+                if reason == REFUSED_GATED_WITHOUT_SCOPE and not from_classified:
+                    # The selection that pointed here is no longer one a visitor
+                    # may hold, so turning them away drops it too -- otherwise
+                    # the picker they land on still carries the stale pointer.
+                    clear_selection(request.session)
                 return _refusal_for(request, reason, as_json)
             return view_func(request, *args, **kwargs)
 

--- a/app/astrodash/core/model_access.py
+++ b/app/astrodash/core/model_access.py
@@ -361,8 +361,37 @@ REFUSED_GATED_WITHOUT_SCOPE = "gated_without_scope"
 REFUSED_SURFACE_NOT_OFFERED = "surface_not_offered"
 
 
+SURFACE_NOT_OFFERED_HEADING = "This view is not available"
+
+
+def render_refusal(request, heading=None, message=None):
+    """Render the access-refusal page.
+
+    Every refusal renders through here, whether it comes from the gate or from
+    the entry-link view, so the disclosure-minimal default cannot drift between
+    the two: a visitor who is refused must not be able to tell one refusal from
+    another.
+
+    Args:
+        request: The current request.
+        heading: Optional heading override; the disclosure-minimal default is
+            used when omitted.
+        message: Optional message override, for a caller whose visitor already
+            knows which model they were using.
+
+    Returns:
+        HttpResponse: The refusal page, with status 403.
+    """
+    return render(
+        request,
+        "astrodash/model_gate_refused.html",
+        {"refusal_heading": heading, "refusal_message": message},
+        status=403,
+    )
+
+
 def _refusal_for(request, reason, as_json):
-    """Build the response for a refused request.
+    """Build the response for a refused guarded request.
 
     Args:
         request: The current request.
@@ -375,15 +404,7 @@ def _refusal_for(request, reason, as_json):
     if reason == REFUSED_SCOPE_LAPSED:
         if as_json:
             return JsonResponse({"error": SCOPE_LAPSED_MESSAGE}, status=403)
-        return render(
-            request,
-            "astrodash/model_gate_refused.html",
-            {
-                "refusal_heading": SCOPE_LAPSED_HEADING,
-                "refusal_message": SCOPE_LAPSED_MESSAGE,
-            },
-            status=403,
-        )
+        return render_refusal(request, SCOPE_LAPSED_HEADING, SCOPE_LAPSED_MESSAGE)
 
     if reason == REFUSED_GATED_WITHOUT_SCOPE:
         if as_json:
@@ -396,23 +417,12 @@ def _refusal_for(request, reason, as_json):
             return HttpResponseRedirect(
                 reverse("astrodash:model_selection") + "?action=classify"
             )
-        return render(
-            request,
-            "astrodash/model_gate_refused.html",
-            {"refusal_heading": None, "refusal_message": None},
-            status=403,
-        )
+        return render_refusal(request)
 
     if as_json:
         return JsonResponse({"error": SURFACE_NOT_OFFERED_MESSAGE}, status=403)
-    return render(
-        request,
-        "astrodash/model_gate_refused.html",
-        {
-            "refusal_heading": "This view is not available",
-            "refusal_message": SURFACE_NOT_OFFERED_MESSAGE,
-        },
-        status=403,
+    return render_refusal(
+        request, SURFACE_NOT_OFFERED_HEADING, SURFACE_NOT_OFFERED_MESSAGE
     )
 
 
@@ -442,7 +452,25 @@ def clear_selection(session) -> None:
     session.modified = True
 
 
-def scoped_flow_refusal(request, action="classify"):
+def _teardown_if_lapsed(session) -> bool:
+    """End a scope that has passed its deadline.
+
+    The single place the lapse condition and its teardown live, so the gate and
+    the flow refusals cannot come to disagree about when a scope is over.
+
+    Args:
+        session: The request's session.
+
+    Returns:
+        True when a lapsed scope was found and torn down.
+    """
+    if scope_model_id(session) and scope_expired(session):
+        end_scope(session)
+        return True
+    return False
+
+
+def scoped_flow_refusal(request):
     """Refuse a flow a scoped session may not enter, or let it through.
 
     A scope reaches classification only, so the batch flow and the selection
@@ -452,14 +480,11 @@ def scoped_flow_refusal(request, action="classify"):
 
     Args:
         request: The current request.
-        action: The selection action this flow belongs to, used when a lapsed
-            scope has to send the visitor back to the picker.
 
     Returns:
         HttpResponse: The refusal, or ``None`` when the request may proceed.
     """
-    if scope_model_id(request.session) and scope_expired(request.session):
-        end_scope(request.session)
+    if _teardown_if_lapsed(request.session):
         return _refusal_for(request, REFUSED_SCOPE_LAPSED, as_json=False)
 
     if live_scope_model_id(request.session) is not None:
@@ -539,8 +564,7 @@ def evaluate_access(session, model_id, route_name):
         One of the ``REFUSED_*`` reasons, or ``None`` when the request may
         proceed.
     """
-    if scope_model_id(session) and scope_expired(session):
-        end_scope(session)
+    if _teardown_if_lapsed(session):
         return REFUSED_SCOPE_LAPSED
 
     if live_scope_model_id(session) is None:

--- a/app/astrodash/core/model_access.py
+++ b/app/astrodash/core/model_access.py
@@ -1,0 +1,309 @@
+"""Entry links, the shared credential, and the model-scoped session.
+
+A model definition can declare that running it requires a shared credential
+(``requires_credential``). Such a model is reachable only by redeeming a
+*model-scoped entry link* -- a signed token naming one model and carrying an
+absolute deadline -- and then presenting the credential. A correct credential
+establishes a *scope*: a session locked to that one model, which expires no
+later than the link that created it.
+
+This module owns the mechanism; the views own the pages. It is deliberately
+small, because the gate is interim: it exists only because no identity layer is
+applied to the AstroDash views today, and the identity-and-access work retires
+it when that work lands.
+
+Three properties are load-bearing and each is easy to get subtly wrong:
+
+* **The deadline is stamped at mint, not evaluated later.** The token carries an
+  absolute expiry rather than being checked against the currently configured
+  window, so shortening that window cannot retroactively move an outstanding
+  link's deadline (nor lengthening it extend one).
+* **The scope carries that same absolute deadline in the session.** Django's
+  ``set_expiry`` treats an integer as *seconds of inactivity* and re-arms on
+  every session write -- and the classify flow writes on every submit -- so it
+  bounds idleness, not lifetime. It is kept only as a secondary bound; the
+  stored deadline is what the gate checks.
+* **Teardown deletes named keys and never calls ``flush()``.** The session is
+  shared with Django's auth framework, so flushing would log out an
+  authenticated visitor. Three key categories are swept: the scope keys, the
+  selection keys, and everything under the classification-artifact prefix.
+"""
+
+import hmac
+import time
+from dataclasses import dataclass
+from typing import Optional
+
+from django.core import signing
+
+from astrodash.core.gate_config import (
+    CREDENTIAL_ENV_VAR,
+    LINK_TTL_ENV_VAR,
+    SIGNING_KEY_NAME,
+    gate_configuration,
+)
+
+# Salt distinct to this purpose, so a token minted here cannot be replayed
+# against any other signed value the project produces.
+ENTRY_LINK_SALT = "astrodash.model-access.entry-link"
+
+# Session keys holding the scope: the one model it names, and the absolute
+# deadline (a POSIX timestamp) it must not outlive.
+SCOPE_MODEL_KEY = "model_scope_model_type"
+SCOPE_DEADLINE_KEY = "model_scope_deadline"
+SCOPE_SESSION_KEYS = (SCOPE_MODEL_KEY, SCOPE_DEADLINE_KEY)
+
+# Session keys holding an ordinary (unscoped) model selection. Teardown clears
+# these too: a scope that left a prior selection standing is how a scope ends up
+# running a model it does not name.
+SELECTION_SESSION_KEYS = ("selected_model_type", "selected_model_id")
+
+# Every session key a classification writes is prefixed with this, which makes
+# the artifact namespace sweepable: anything added under it is torn down without
+# being enumerated here.
+ARTIFACT_KEY_PREFIX = "classify_"
+
+
+class GateNotConfigured(RuntimeError):
+    """Raised when the gate is used while its deployment values are missing.
+
+    Startup validation makes this unreachable for a deployment whose roster
+    contains a gated model, so it means the gate was driven in an environment
+    that never intended to serve one.
+    """
+
+
+class EntryLinkRefused(Exception):
+    """Raised for any entry link that does not grant access.
+
+    One exception covers tampering, a malformed payload, and a lapsed deadline
+    alike, because the refusal must disclose nothing about which models exist:
+    the caller cannot tell the cases apart, so it cannot leak them.
+    """
+
+
+@dataclass(frozen=True)
+class EntryLink:
+    """A redeemed entry link.
+
+    Attributes:
+        model_id: The one model the link names.
+        expires_at: Absolute POSIX timestamp the link -- and any scope it
+            establishes -- expires at.
+    """
+
+    model_id: str
+    expires_at: float
+
+
+def _now() -> float:
+    """Return the current time as a POSIX timestamp.
+
+    Indirection so tests can move time without touching the clock.
+
+    Returns:
+        The current POSIX timestamp.
+    """
+    return time.time()
+
+
+def _require(name: str) -> str:
+    """Read one normalized gate configuration value, or fail closed.
+
+    Args:
+        name: The configuration name, as an operator sets it.
+
+    Returns:
+        The configured value.
+
+    Raises:
+        GateNotConfigured: If the value is unset, blank, or left at a committed
+            default.
+    """
+    value = gate_configuration().get(name)
+    if value is None:
+        raise GateNotConfigured(
+            f"The model access gate is not configured: {name} is unset, empty, "
+            "or left at a committed default."
+        )
+    return value
+
+
+def link_ttl_seconds() -> int:
+    """Return the configured entry-link expiry window, in seconds.
+
+    Returns:
+        The window as a positive integer.
+
+    Raises:
+        GateNotConfigured: If the window is unconfigured.
+    """
+    return int(_require(LINK_TTL_ENV_VAR))
+
+
+def mint_entry_link(model_id: str, ttl_seconds: Optional[int] = None) -> str:
+    """Mint a signed entry-link token for one model.
+
+    The deadline is computed once, here, and travels inside the token, so the
+    link's lifetime is fixed at mint rather than re-derived at redemption.
+
+    Args:
+        model_id: The model the link grants access to.
+        ttl_seconds: Optional window override, in seconds; the configured
+            window is used when omitted.
+
+    Returns:
+        The signed token, to be placed in the entry-link path.
+
+    Raises:
+        GateNotConfigured: If the signing key or (absent an override) the
+            window is unconfigured.
+    """
+    window = link_ttl_seconds() if ttl_seconds is None else int(ttl_seconds)
+    payload = {"model": model_id, "expires_at": _now() + window}
+    return signing.dumps(payload, key=_require(SIGNING_KEY_NAME), salt=ENTRY_LINK_SALT)
+
+
+def redeem_entry_link(token: str) -> EntryLink:
+    """Resolve an entry-link token, refusing anything that does not grant access.
+
+    The token is not loaded with a ``max_age``: the deadline it carries was
+    stamped at mint and is authoritative, so re-deriving one from the currently
+    configured window would let a configuration change move an outstanding
+    link's deadline. ``SignatureExpired`` subclasses ``BadSignature``, so the
+    single catch below covers it however the token was produced.
+
+    Args:
+        token: The signed token from the entry-link path.
+
+    Returns:
+        The resolved :class:`EntryLink`.
+
+    Raises:
+        EntryLinkRefused: If the token is malformed, signed with another key,
+            tampered with, or past its deadline.
+        GateNotConfigured: If the signing key is unconfigured.
+    """
+    key = _require(SIGNING_KEY_NAME)
+    try:
+        payload = signing.loads(token, key=key, salt=ENTRY_LINK_SALT)
+    except signing.BadSignature as exc:
+        raise EntryLinkRefused("Entry link is not valid.") from exc
+
+    model_id = payload.get("model") if isinstance(payload, dict) else None
+    expires_at = payload.get("expires_at") if isinstance(payload, dict) else None
+    if not model_id or not isinstance(expires_at, (int, float)):
+        raise EntryLinkRefused("Entry link is not valid.")
+
+    if _now() >= expires_at:
+        raise EntryLinkRefused("Entry link is not valid.")
+
+    return EntryLink(model_id=model_id, expires_at=float(expires_at))
+
+
+def credential_matches(submitted: Optional[str]) -> bool:
+    """Compare a submitted credential against the configured one, in constant time.
+
+    Args:
+        submitted: The credential as posted, or ``None`` when absent.
+
+    Returns:
+        True when it matches the configured shared credential.
+
+    Raises:
+        GateNotConfigured: If no credential is configured.
+    """
+    expected = _require(CREDENTIAL_ENV_VAR)
+    return hmac.compare_digest(str(submitted or ""), expected)
+
+
+def end_scope(session) -> None:
+    """Clear the scope, any model selection, and every classification artifact.
+
+    Never calls ``flush()``: the session is shared with Django's auth
+    framework, so flushing would log out an authenticated visitor along with
+    ending the scope. Both redemption and the explicit end call this, which is
+    why a prior *selection* is swept as well -- leaving one standing is how a
+    scope ends up running a model it does not name.
+
+    Args:
+        session: The request's session.
+    """
+    for key in SCOPE_SESSION_KEYS + SELECTION_SESSION_KEYS:
+        session.pop(key, None)
+    for key in [k for k in list(session.keys()) if k.startswith(ARTIFACT_KEY_PREFIX)]:
+        session.pop(key, None)
+    session.modified = True
+
+
+def begin_scope(session, link: EntryLink) -> None:
+    """Establish a session scoped to one model, bounded by its link's deadline.
+
+    Any prior scope, selection, and classification artifact is cleared first,
+    so the scope is written over a clean session rather than beside stale
+    state.
+
+    The scoped model is also written as the session's selection, so every
+    surface that already reads a selection sees the scoped model; the scope
+    keys remain the authority, and the gate resolves them first.
+
+    Args:
+        session: The request's session.
+        link: The redeemed entry link that grants the scope.
+    """
+    end_scope(session)
+    session[SCOPE_MODEL_KEY] = link.model_id
+    session[SCOPE_DEADLINE_KEY] = link.expires_at
+    session["selected_model_type"] = link.model_id
+
+    # Secondary bound only: Django re-arms this on every session write, so it
+    # caps idleness rather than lifetime. The stored deadline above is what the
+    # gate enforces.
+    remaining = int(max(0, link.expires_at - _now()))
+    session.set_expiry(remaining)
+
+
+def scope_model_id(session) -> Optional[str]:
+    """Return the model a session is scoped to, ignoring its deadline.
+
+    Args:
+        session: The request's session.
+
+    Returns:
+        The scoped model id, or ``None`` when the session holds no scope.
+    """
+    return session.get(SCOPE_MODEL_KEY)
+
+
+def scope_expired(session) -> bool:
+    """Whether a session's scope has passed the deadline it was granted with.
+
+    Args:
+        session: The request's session.
+
+    Returns:
+        True when a scope is present and its stored deadline has passed. A
+        scope with no stored deadline is treated as expired: it cannot be
+        proven to be within one.
+    """
+    if not scope_model_id(session):
+        return False
+    deadline = session.get(SCOPE_DEADLINE_KEY)
+    if not isinstance(deadline, (int, float)):
+        return True
+    return _now() >= deadline
+
+
+def live_scope_model_id(session) -> Optional[str]:
+    """Return the scoped model only while the scope is still within its deadline.
+
+    Args:
+        session: The request's session.
+
+    Returns:
+        The scoped model id, or ``None`` when there is no scope or it has
+        lapsed.
+    """
+    if scope_expired(session):
+        return None
+    return scope_model_id(session)

--- a/app/astrodash/core/model_access.py
+++ b/app/astrodash/core/model_access.py
@@ -65,6 +65,12 @@ SCOPE_SESSION_KEYS = (SCOPE_MODEL_KEY, SCOPE_DEADLINE_KEY)
 # running a model it does not name.
 SELECTION_SESSION_KEYS = ("selected_model_type", "selected_model_id")
 
+# The session key holding the model the last classification ran, written by the
+# classify view. A supporting route that consumes a classification artifact
+# authorizes from this rather than from the selection (KTD5), so the two sides
+# are named here rather than agreeing by spelling.
+CLASSIFIED_MODEL_KEY = "classify_model_type"
+
 # Every session key a classification writes is prefixed with this, which makes
 # the artifact namespace sweepable: anything added under it is torn down without
 # being enumerated here.
@@ -259,6 +265,11 @@ def begin_scope(session, link: EntryLink) -> None:
         link: The redeemed entry link that grants the scope.
     """
     end_scope(session)
+    # Rotate the session identifier as the scope is granted, the way Django's
+    # own login() does: authorization must never be written into a session id
+    # that was in circulation before it was earned. cycle_key() keeps the
+    # session's data, so an authenticated visitor stays logged in.
+    session.cycle_key()
     session[SCOPE_MODEL_KEY] = link.model_id
     session[SCOPE_DEADLINE_KEY] = link.expires_at
     session["selected_model_type"] = link.model_id
@@ -390,13 +401,16 @@ def render_refusal(request, heading=None, message=None):
     )
 
 
-def _refusal_for(request, reason, as_json):
+def _refusal_for(request, reason, as_json, route_name=None):
     """Build the response for a refused guarded request.
 
     Args:
         request: The current request.
         reason: One of the ``REFUSED_*`` reasons.
         as_json: Whether the caller is a JSON route.
+        route_name: The guarded supporting route's name, or ``None`` for the
+            classification view -- the one page an ordinary visitor can land on
+            with a stale selection, and so the one returned to the picker.
 
     Returns:
         HttpResponse: The refusal.
@@ -409,8 +423,8 @@ def _refusal_for(request, reason, as_json):
     if reason == REFUSED_GATED_WITHOUT_SCOPE:
         if as_json:
             return JsonResponse({"error": SURFACE_NOT_OFFERED_MESSAGE}, status=403)
-        if request.path == reverse("astrodash:classify"):
-            # The classification page is the one an ordinary visitor can land on
+        if route_name is None:
+            # The classification view, which an ordinary visitor can land on
             # with a stale selection, so it is returned to the picker rather
             # than shown an error page.
             messages.error(request, GATED_WITHOUT_SCOPE_MESSAGE)
@@ -519,7 +533,16 @@ def revalidate_session_model(request, action="classify"):
     scoped = scope_model_id(request.session)
     if scoped:
         definition = get_definition(scoped)
-        if definition is not None and not definition.requires_credential:
+        if definition is None or not definition.is_active:
+            # The scoped model has been retired or removed since the scope was
+            # granted, so there is nothing left to reach. R35 covers this the
+            # same way it covers a public selection that stopped being usable.
+            end_scope(request.session)
+            messages.error(request, MODEL_NO_LONGER_SELECTABLE_MESSAGE)
+            return HttpResponseRedirect(
+                reverse("astrodash:model_selection") + f"?action={action}"
+            )
+        if not definition.requires_credential:
             # Published: there is nothing left to scope, so the scope dissolves
             # into an ordinary selection of the same model.
             end_scope(request.session)
@@ -605,7 +628,7 @@ def model_access_required(route_name=None, *, from_classified=False, as_json=Fal
         @wraps(view_func)
         def wrapper(request, *args, **kwargs):
             if from_classified:
-                model_id = request.session.get("classify_model_type")
+                model_id = request.session.get(CLASSIFIED_MODEL_KEY)
             else:
                 model_id = effective_model_id(request.session)
             reason = evaluate_access(request.session, model_id, route_name)
@@ -615,15 +638,18 @@ def model_access_required(route_name=None, *, from_classified=False, as_json=Fal
                     # may hold, so turning them away drops it too -- otherwise
                     # the picker they land on still carries the stale pointer.
                     clear_selection(request.session)
-                return _refusal_for(request, reason, as_json)
+                return _refusal_for(request, reason, as_json, route_name)
             return view_func(request, *args, **kwargs)
 
-        # Marker the coverage guard reads. A decorator is opt-in by nature, so a
+        # Markers the coverage guard reads. A decorator is opt-in by nature, so a
         # surface added later could silently omit the gate; the guard walks every
-        # route the surface map declares and asserts this attribute is present.
-        # ``functools.wraps`` copies it outward, so an additional decorator
-        # stacked above this one does not hide it.
+        # route the surface map declares and asserts not merely that the gate is
+        # applied but that it is bound to that route -- a gate applied without
+        # its route name would skip the surface check while still looking
+        # guarded. ``functools.wraps`` copies these outward, so an additional
+        # decorator stacked above this one does not hide them.
         wrapper.model_access_guarded = True
+        wrapper.model_access_route = route_name
         return wrapper
 
     return decorate

--- a/app/astrodash/core/model_access.py
+++ b/app/astrodash/core/model_access.py
@@ -594,6 +594,12 @@ def model_access_required(route_name=None, *, from_classified=False, as_json=Fal
                 return _refusal_for(request, reason, as_json)
             return view_func(request, *args, **kwargs)
 
+        # Marker the coverage guard reads. A decorator is opt-in by nature, so a
+        # surface added later could silently omit the gate; the guard walks every
+        # route the surface map declares and asserts this attribute is present.
+        # ``functools.wraps`` copies it outward, so an additional decorator
+        # stacked above this one does not hide it.
+        wrapper.model_access_guarded = True
         return wrapper
 
     return decorate

--- a/app/astrodash/forms.py
+++ b/app/astrodash/forms.py
@@ -4,15 +4,24 @@ import json
 import ast
 
 from astrodash.infrastructure.ml.model_registry import (
-    active_definitions,
     default_definition,
     get_definition,
+    listed_definitions,
 )
 
 
 def _builtin_model_choices():
-    """Return (id, title) choices for the active built-in models, in registry order."""
-    return [(d.id, d.title) for d in active_definitions()]
+    """Return (id, title) choices for the listed built-in models, in registry order.
+
+    Listing, not lifecycle status, decides what a choice control offers: an
+    unlisted model must appear in no control an ordinary visitor can reach.
+    Because a ``ChoiceField`` also validates against its choices, dropping an
+    unlisted model here is what makes a hand-crafted POST naming it invalid.
+
+    Returns:
+        A list of ``(id, title)`` pairs in registry order.
+    """
+    return [(d.id, d.title) for d in listed_definitions()]
 
 
 def _classify_model_choices():

--- a/app/astrodash/forms.py
+++ b/app/astrodash/forms.py
@@ -137,10 +137,28 @@ class ClassifyForm(forms.Form):
         widget=forms.NumberInput(attrs={'class': 'form-control', 'step': 'any'})
     )
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, effective_model=None, **kwargs):
+        """Build the form, optionally bound to the model that will actually run.
+
+        Args:
+            *args: Standard form positional arguments (data, files).
+            effective_model: The model the view will run -- the scoped model in
+                a scoped session, otherwise the session's selection. It becomes
+                the field's initial value, it is added to the choices when the
+                registry knows it (a gated model is unlisted, so it is in no
+                listed choice set, and a scoped submission would otherwise fail
+                validation before the view consulted the scope), and it decides
+                the redshift policy this form validates against.
+            **kwargs: Standard form keyword arguments.
+        """
         super().__init__(*args, **kwargs)
-        self.fields['model'].choices = _classify_model_choices()
-        self.fields['model'].initial = default_definition().id
+        self.effective_model = effective_model
+        choices = _classify_model_choices()
+        definition = get_definition(effective_model) if effective_model else None
+        if definition is not None and definition.id not in [c[0] for c in choices]:
+            choices.append((definition.id, definition.title))
+        self.fields['model'].choices = choices
+        self.fields['model'].initial = effective_model or default_definition().id
 
     def clean(self):
         cleaned_data = super().clean()
@@ -148,7 +166,9 @@ class ClassifyForm(forms.Form):
         supernova_name = cleaned_data.get('supernova_name')
         known_z = cleaned_data.get('known_z')
         redshift = cleaned_data.get('redshift')
-        model = cleaned_data.get('model')
+        # The redshift policy follows the model that will actually run, not the
+        # submitted field: inside a scoped flow the field is not authoritative.
+        model = self.effective_model or cleaned_data.get('model')
 
         if not file and not supernova_name:
             raise forms.ValidationError("Please provide either a spectrum file or a Supernova Name.")

--- a/app/astrodash/forms.py
+++ b/app/astrodash/forms.py
@@ -2,12 +2,58 @@ from django import forms
 from django.core.validators import FileExtensionValidator
 import json
 import ast
+from typing import Optional
 
 from astrodash.infrastructure.ml.model_registry import (
+    REDSHIFT_INPUT_NONE,
+    REDSHIFT_INPUT_OPTIONAL,
+    REDSHIFT_INPUT_REQUIRED,
     default_definition,
     get_definition,
     listed_definitions,
 )
+
+# The message both redshift gates (this form and the batch view's own check)
+# raise when a model that requires a redshift is submitted without one. It
+# names no model: the requirement comes from the selected model's declared
+# policy, so any model can carry it.
+REDSHIFT_REQUIRED_MESSAGE = "Redshift is required for the selected model."
+
+
+def redshift_input_policy(model_id: Optional[str]) -> str:
+    """Resolve a model selection to its declared redshift input policy.
+
+    Args:
+        model_id: The selected ``model_type``, or ``None`` when no model is
+            selected.
+
+    Returns:
+        One of :data:`REDSHIFT_INPUT_REQUIRED`, :data:`REDSHIFT_INPUT_OPTIONAL`
+        or :data:`REDSHIFT_INPUT_NONE`. A selection the registry cannot resolve
+        -- a user-uploaded model, or no selection at all -- falls back to
+        :data:`REDSHIFT_INPUT_OPTIONAL`, which is the behavior that path has
+        always had.
+    """
+    definition = get_definition(model_id) if model_id else None
+    if definition is None:
+        return REDSHIFT_INPUT_OPTIONAL
+    return definition.redshift_input
+
+
+def takes_redshift_input(model_id: Optional[str]) -> bool:
+    """Whether a model selection takes a redshift as an input at all.
+
+    Drives whether the redshift field and the Known Redshift checkbox render:
+    a model that declines redshift shows neither control.
+
+    Args:
+        model_id: The selected ``model_type``, or ``None`` when no model is
+            selected.
+
+    Returns:
+        True unless the selected model declares :data:`REDSHIFT_INPUT_NONE`.
+    """
+    return redshift_input_policy(model_id) != REDSHIFT_INPUT_NONE
 
 
 def _builtin_model_choices():
@@ -110,11 +156,11 @@ class ClassifyForm(forms.Form):
         if known_z and redshift is None:
             self.add_error('redshift', "Redshift is required when 'Known Redshift' is checked.")
 
-        # Require redshift only for models whose definition demands it (built-in
-        # Transformer today); user-uploaded models use 0.0 if missing.
-        definition = get_definition(model)
-        if definition is not None and definition.requires_redshift and redshift is None:
-            self.add_error('redshift', "Redshift is required for Transformer model.")
+        # Require a redshift only when the selected model's declared policy
+        # says it is a required input; an optional-input or unresolvable
+        # selection (user-uploaded models use 0.0 if missing) passes without one.
+        if redshift_input_policy(model) == REDSHIFT_INPUT_REQUIRED and redshift is None:
+            self.add_error('redshift', REDSHIFT_REQUIRED_MESSAGE)
 
         return cleaned_data
 

--- a/app/astrodash/infrastructure/ml/model_registry/__init__.py
+++ b/app/astrodash/infrastructure/ml/model_registry/__init__.py
@@ -19,7 +19,7 @@ registry for independently contributed models is a later runway, not built
 here.
 """
 
-from typing import Mapping, Optional, Tuple
+from typing import AbstractSet, Mapping, Optional, Tuple
 
 from astrodash.infrastructure.ml.model_registry._model_definition import (
     REDSHIFT_INPUT_NONE,
@@ -27,6 +27,8 @@ from astrodash.infrastructure.ml.model_registry._model_definition import (
     REDSHIFT_INPUT_REQUIRED,
     STATUS_ACTIVE,
     STATUS_RETIRED,
+    SURFACE_CLASSIFICATION,
+    SURFACE_DASH_TWINS,
     ModelDefinition,
 )
 from astrodash.infrastructure.ml.model_registry.definitions.dash import DASH
@@ -45,9 +47,12 @@ __all__ = [
     "REDSHIFT_INPUT_REQUIRED",
     "REDSHIFT_INPUT_OPTIONAL",
     "REDSHIFT_INPUT_NONE",
+    "SURFACE_CLASSIFICATION",
+    "SURFACE_DASH_TWINS",
     "MODELS",
     "validate_registry",
     "validate_gate_configuration",
+    "validate_surfaces",
     "get_definition",
     "active_definitions",
     "listed_definitions",
@@ -143,6 +148,49 @@ def validate_gate_configuration(
             f"left at a committed default: {missing}. "
             f"Gated models in the registry: {gated}."
         )
+
+
+def validate_surfaces(
+    models: Tuple[ModelDefinition, ...],
+    known_surface_ids: AbstractSet[str],
+) -> None:
+    """Validate the result surfaces every definition declares.
+
+    The known ids are passed in rather than imported, because a surface id only
+    means something once the web layer can render it, and nothing under the ML
+    infrastructure package imports Django or knows about URL names. The caller
+    (the app-ready hook) supplies the web layer's surface map keys, so an id
+    with no presentation refuses startup instead of rendering as a broken tab.
+
+    Args:
+        models: The collection of model definitions to check.
+        known_surface_ids: Every surface id the web layer can resolve.
+
+    Raises:
+        ValueError: If a definition declares no surfaces, omits the
+            classification surface, or declares an id the web layer does not
+            know. The message names the offending model and ids.
+    """
+    for model in models:
+        if not model.surfaces:
+            raise ValueError(
+                f"Model '{model.id}' declares no result surfaces; every model "
+                f"must declare at least '{SURFACE_CLASSIFICATION}'."
+            )
+
+        unknown = [s for s in model.surfaces if s not in known_surface_ids]
+        if unknown:
+            raise ValueError(
+                f"Model '{model.id}' declares unknown result surfaces: "
+                f"{unknown}. Known surfaces: {sorted(known_surface_ids)}."
+            )
+
+        if SURFACE_CLASSIFICATION not in model.surfaces:
+            raise ValueError(
+                f"Model '{model.id}' must declare the "
+                f"'{SURFACE_CLASSIFICATION}' surface; declared: "
+                f"{list(model.surfaces)}."
+            )
 
 
 def get_definition(model_id: str) -> Optional[ModelDefinition]:

--- a/app/astrodash/infrastructure/ml/model_registry/__init__.py
+++ b/app/astrodash/infrastructure/ml/model_registry/__init__.py
@@ -19,9 +19,12 @@ registry for independently contributed models is a later runway, not built
 here.
 """
 
-from typing import Optional, Tuple
+from typing import Mapping, Optional, Tuple
 
 from astrodash.infrastructure.ml.model_registry._model_definition import (
+    REDSHIFT_INPUT_NONE,
+    REDSHIFT_INPUT_OPTIONAL,
+    REDSHIFT_INPUT_REQUIRED,
     STATUS_ACTIVE,
     STATUS_RETIRED,
     ModelDefinition,
@@ -39,10 +42,15 @@ __all__ = [
     "ModelDefinition",
     "STATUS_ACTIVE",
     "STATUS_RETIRED",
+    "REDSHIFT_INPUT_REQUIRED",
+    "REDSHIFT_INPUT_OPTIONAL",
+    "REDSHIFT_INPUT_NONE",
     "MODELS",
     "validate_registry",
+    "validate_gate_configuration",
     "get_definition",
     "active_definitions",
+    "listed_definitions",
     "default_definition",
 ]
 
@@ -62,8 +70,10 @@ def validate_registry(models: Tuple[ModelDefinition, ...]) -> None:
         models: The collection of model definitions to validate.
 
     Raises:
-        ValueError: If model ids are not unique, or if the number of active
-            definitions marked as default is not exactly one.
+        ValueError: If model ids are not unique, if the number of active
+            definitions marked as default is not exactly one, if a definition
+            requiring a credential is also listed, or if the active default is
+            unlisted or requires a credential.
     """
     ids = [m.id for m in models]
     if len(ids) != len(set(ids)):
@@ -74,6 +84,64 @@ def validate_registry(models: Tuple[ModelDefinition, ...]) -> None:
         raise ValueError(
             "Exactly one active model must be the default; "
             f"found {len(active_defaults)}: {[m.id for m in active_defaults]}"
+        )
+
+    # A gated model is never listed: listing it would advertise a model that
+    # only a credentialed visitor can run, and would leak its existence.
+    gated_and_listed = [m.id for m in models if m.requires_credential and m.listed]
+    if gated_and_listed:
+        raise ValueError(
+            "A model requiring a credential must not be listed; "
+            f"offending models: {gated_and_listed}"
+        )
+
+    # The default is what every visitor lands on, so it must be reachable by
+    # anyone and visible on the selection surfaces.
+    default = active_defaults[0]
+    if not default.listed or default.requires_credential:
+        raise ValueError(
+            "The active default model must be listed and must not require a "
+            f"credential; '{default.id}' is listed={default.listed}, "
+            f"requires_credential={default.requires_credential}"
+        )
+
+
+def validate_gate_configuration(
+    models: Tuple[ModelDefinition, ...],
+    configuration: Mapping[str, Optional[str]],
+) -> None:
+    """Validate that a roster containing a gated model is configured to serve it.
+
+    A gated model must never be served without its credential prompt, so a
+    deployment missing any part of the gate's configuration fails closed: the
+    caller (the app-ready hook) lets this propagate and the process refuses to
+    start.
+
+    Configuration is passed in rather than read here, because nothing under the
+    ML infrastructure package imports Django or reads the environment. The
+    caller normalizes each value, mapping "unset", "blank", and "left at a
+    committed default" alike to ``None``.
+
+    Args:
+        models: The collection of model definitions to check.
+        configuration: Mapping of configuration name (as an operator sets it)
+            to its normalized value, with ``None`` meaning unconfigured.
+
+    Raises:
+        ValueError: If any model requires a credential while one or more
+            configuration values are unconfigured. The message names both the
+            gated models and the missing configuration.
+    """
+    gated = [m.id for m in models if m.requires_credential]
+    if not gated:
+        return
+
+    missing = sorted(name for name, value in configuration.items() if value is None)
+    if missing:
+        raise ValueError(
+            "Gated models require gate configuration that is unset, empty, or "
+            f"left at a committed default: {missing}. "
+            f"Gated models in the registry: {gated}."
         )
 
 
@@ -102,6 +170,20 @@ def active_definitions() -> Tuple[ModelDefinition, ...]:
         appear in ``MODELS``.
     """
     return tuple(m for m in MODELS if m.is_active)
+
+
+def listed_definitions() -> Tuple[ModelDefinition, ...]:
+    """Return the definitions offered on the selection surfaces, in order.
+
+    Listing and lifecycle status are separate questions: a model can be active
+    (it runs, and it resolves by id) while being unlisted (no card, no choice
+    control). A retired model is never listed.
+
+    Returns:
+        The definitions that are both active and listed, in the order they
+        appear in ``MODELS``.
+    """
+    return tuple(m for m in MODELS if m.is_active and m.listed)
 
 
 def default_definition() -> ModelDefinition:

--- a/app/astrodash/infrastructure/ml/model_registry/_model_definition.py
+++ b/app/astrodash/infrastructure/ml/model_registry/_model_definition.py
@@ -106,15 +106,6 @@ class ModelDefinition:
         return self.status == STATUS_ACTIVE
 
     @property
-    def requires_redshift(self) -> bool:
-        """Whether a redshift must be supplied to classify with this model.
-
-        Derived from :attr:`redshift_input` so the read sites that predate the
-        three-way policy keep working unchanged until they are migrated.
-        """
-        return self.redshift_input == REDSHIFT_INPUT_REQUIRED
-
-    @property
     def supports_twins(self) -> bool:
         """Whether a classification with this model can seed the twins search.
 

--- a/app/astrodash/infrastructure/ml/model_registry/_model_definition.py
+++ b/app/astrodash/infrastructure/ml/model_registry/_model_definition.py
@@ -12,10 +12,18 @@ from typing import Optional, Tuple, Type
 
 from astrodash.infrastructure.ml.classifiers.base import BaseClassifier
 
-# Lifecycle status values. "active" models appear on the selection surfaces;
-# "retired" models are hidden from new use but still resolve their label/fields.
+# Lifecycle status values. "active" models are offered for new use; "retired"
+# models are hidden from new use but still resolve their label/fields.
+# Whether a model is *listed* is a separate declaration (see ``listed`` below).
 STATUS_ACTIVE = "active"
 STATUS_RETIRED = "retired"
+
+# Redshift input policies. A model declares redshift as a required input, an
+# optional input, or not an input at all. This is independent of whether the
+# model *estimates* a redshift as an output (``supports_redshift_estimation``).
+REDSHIFT_INPUT_REQUIRED = "required"
+REDSHIFT_INPUT_OPTIONAL = "optional"
+REDSHIFT_INPUT_NONE = "none"
 
 
 @dataclass(frozen=True)
@@ -33,10 +41,21 @@ class ModelDefinition:
             ``None`` for models with no icon.
         recommended: Whether the card shows the RECOMMENDED badge.
         status: Lifecycle status, :data:`STATUS_ACTIVE` or :data:`STATUS_RETIRED`.
+        listed: Whether the model is offered on the selection surfaces (cards,
+            form choice controls). Listing is presentation only and never
+            access control: an unlisted model that requires no credential
+            stays reachable by anyone who names it. A gated model is always
+            unlisted, and the active default is always listed.
         is_default: Whether this is the default selected model. Exactly one
             active definition must be the default.
-        requires_redshift: Whether a redshift is required to classify with this
-            model (drives the classify-form and batch-view validation gates).
+        requires_credential: Whether running the model requires the shared
+            credential, reached only through a model-scoped entry link. Implies
+            ``listed`` is ``False``.
+        redshift_input: Redshift input policy -- one of
+            :data:`REDSHIFT_INPUT_REQUIRED`, :data:`REDSHIFT_INPUT_OPTIONAL`,
+            or :data:`REDSHIFT_INPUT_NONE`. Drives the classify-form and
+            batch-view validation gates and whether the redshift controls
+            render at all.
         preprocessing: Identifier of the preprocessing variant this model needs,
             consumed by the spectrum processing service (e.g. ``"dash"``).
         supports_twins: Whether a classification with this model can seed the
@@ -58,8 +77,10 @@ class ModelDefinition:
     icon: Optional[str]
     recommended: bool
     status: str
+    listed: bool
     is_default: bool
-    requires_redshift: bool
+    requires_credential: bool
+    redshift_input: str
     preprocessing: str
     supports_twins: bool
     supports_redshift_estimation: bool
@@ -71,3 +92,12 @@ class ModelDefinition:
     def is_active(self) -> bool:
         """Whether the model is currently active (not retired)."""
         return self.status == STATUS_ACTIVE
+
+    @property
+    def requires_redshift(self) -> bool:
+        """Whether a redshift must be supplied to classify with this model.
+
+        Derived from :attr:`redshift_input` so the read sites that predate the
+        three-way policy keep working unchanged until they are migrated.
+        """
+        return self.redshift_input == REDSHIFT_INPUT_REQUIRED

--- a/app/astrodash/infrastructure/ml/model_registry/_model_definition.py
+++ b/app/astrodash/infrastructure/ml/model_registry/_model_definition.py
@@ -104,13 +104,3 @@ class ModelDefinition:
     def is_active(self) -> bool:
         """Whether the model is currently active (not retired)."""
         return self.status == STATUS_ACTIVE
-
-    @property
-    def supports_twins(self) -> bool:
-        """Whether a classification with this model can seed the twins search.
-
-        Derived from :attr:`surfaces` so the declared list is the sole
-        authority for the DASH Twins surface. The read site that predates the
-        list keeps working unchanged until it is migrated.
-        """
-        return SURFACE_DASH_TWINS in self.surfaces

--- a/app/astrodash/infrastructure/ml/model_registry/_model_definition.py
+++ b/app/astrodash/infrastructure/ml/model_registry/_model_definition.py
@@ -25,6 +25,15 @@ REDSHIFT_INPUT_REQUIRED = "required"
 REDSHIFT_INPUT_OPTIONAL = "optional"
 REDSHIFT_INPUT_NONE = "none"
 
+# Result surface ids. A definition declares these as opaque identifiers; how a
+# surface presents itself (tab title, pane markup, supporting routes) is
+# web-layer knowledge and lives in ``astrodash.surfaces``, because nothing here
+# imports Django or knows about URL names. Every definition must declare
+# :data:`SURFACE_CLASSIFICATION` -- a model that classifies always has a
+# classification result to show.
+SURFACE_CLASSIFICATION = "classification"
+SURFACE_DASH_TWINS = "dash_twins"
+
 
 @dataclass(frozen=True)
 class ModelDefinition:
@@ -58,8 +67,11 @@ class ModelDefinition:
             render at all.
         preprocessing: Identifier of the preprocessing variant this model needs,
             consumed by the spectrum processing service (e.g. ``"dash"``).
-        supports_twins: Whether a classification with this model can seed the
-            FIND TWINS embedding search.
+        surfaces: Ordered ids of the result surfaces this model offers, the
+            first being the default tab. Only declared surfaces render, in this
+            order. The ids are opaque here and resolved through the web layer's
+            surface map; the list must be non-empty and must include
+            :data:`SURFACE_CLASSIFICATION`.
         supports_redshift_estimation: Whether template-based redshift estimation
             is offered for this model.
         supports_template_overlays: Whether the result view offers the template
@@ -82,7 +94,7 @@ class ModelDefinition:
     requires_credential: bool
     redshift_input: str
     preprocessing: str
-    supports_twins: bool
+    surfaces: Tuple[str, ...]
     supports_redshift_estimation: bool
     supports_template_overlays: bool
     supports_rlap: bool
@@ -101,3 +113,13 @@ class ModelDefinition:
         three-way policy keep working unchanged until they are migrated.
         """
         return self.redshift_input == REDSHIFT_INPUT_REQUIRED
+
+    @property
+    def supports_twins(self) -> bool:
+        """Whether a classification with this model can seed the twins search.
+
+        Derived from :attr:`surfaces` so the declared list is the sole
+        authority for the DASH Twins surface. The read site that predates the
+        list keeps working unchanged until it is migrated.
+        """
+        return SURFACE_DASH_TWINS in self.surfaces

--- a/app/astrodash/infrastructure/ml/model_registry/definitions/dash.py
+++ b/app/astrodash/infrastructure/ml/model_registry/definitions/dash.py
@@ -4,6 +4,8 @@ from astrodash.infrastructure.ml.classifiers.dash_classifier import DashClassifi
 from astrodash.infrastructure.ml.model_registry._model_definition import (
     REDSHIFT_INPUT_OPTIONAL,
     STATUS_ACTIVE,
+    SURFACE_CLASSIFICATION,
+    SURFACE_DASH_TWINS,
     ModelDefinition,
 )
 
@@ -21,7 +23,7 @@ DASH = ModelDefinition(
     requires_credential=False,
     redshift_input=REDSHIFT_INPUT_OPTIONAL,
     preprocessing="dash",
-    supports_twins=True,
+    surfaces=(SURFACE_CLASSIFICATION, SURFACE_DASH_TWINS),
     supports_redshift_estimation=True,
     supports_template_overlays=True,
     supports_rlap=True,

--- a/app/astrodash/infrastructure/ml/model_registry/definitions/dash.py
+++ b/app/astrodash/infrastructure/ml/model_registry/definitions/dash.py
@@ -2,6 +2,7 @@
 
 from astrodash.infrastructure.ml.classifiers.dash_classifier import DashClassifier
 from astrodash.infrastructure.ml.model_registry._model_definition import (
+    REDSHIFT_INPUT_OPTIONAL,
     STATUS_ACTIVE,
     ModelDefinition,
 )
@@ -15,8 +16,10 @@ DASH = ModelDefinition(
     icon="bi-flask",
     recommended=True,
     status=STATUS_ACTIVE,
+    listed=True,
     is_default=False,
-    requires_redshift=False,
+    requires_credential=False,
+    redshift_input=REDSHIFT_INPUT_OPTIONAL,
     preprocessing="dash",
     supports_twins=True,
     supports_redshift_estimation=True,

--- a/app/astrodash/infrastructure/ml/model_registry/definitions/transformer.py
+++ b/app/astrodash/infrastructure/ml/model_registry/definitions/transformer.py
@@ -4,6 +4,7 @@ from astrodash.infrastructure.ml.classifiers.transformer_classifier import (
     TransformerClassifier,
 )
 from astrodash.infrastructure.ml.model_registry._model_definition import (
+    REDSHIFT_INPUT_REQUIRED,
     STATUS_ACTIVE,
     ModelDefinition,
 )
@@ -17,8 +18,10 @@ TRANSFORMER = ModelDefinition(
     icon=None,
     recommended=False,
     status=STATUS_ACTIVE,
+    listed=True,
     is_default=True,
-    requires_redshift=True,
+    requires_credential=False,
+    redshift_input=REDSHIFT_INPUT_REQUIRED,
     preprocessing="transformer",
     supports_twins=False,
     supports_redshift_estimation=False,

--- a/app/astrodash/infrastructure/ml/model_registry/definitions/transformer.py
+++ b/app/astrodash/infrastructure/ml/model_registry/definitions/transformer.py
@@ -6,6 +6,7 @@ from astrodash.infrastructure.ml.classifiers.transformer_classifier import (
 from astrodash.infrastructure.ml.model_registry._model_definition import (
     REDSHIFT_INPUT_REQUIRED,
     STATUS_ACTIVE,
+    SURFACE_CLASSIFICATION,
     ModelDefinition,
 )
 
@@ -23,7 +24,7 @@ TRANSFORMER = ModelDefinition(
     requires_credential=False,
     redshift_input=REDSHIFT_INPUT_REQUIRED,
     preprocessing="transformer",
-    supports_twins=False,
+    surfaces=(SURFACE_CLASSIFICATION,),
     supports_redshift_estimation=False,
     supports_template_overlays=False,
     supports_rlap=False,

--- a/app/astrodash/management/commands/mint_model_link.py
+++ b/app/astrodash/management/commands/mint_model_link.py
@@ -67,6 +67,11 @@ class Command(BaseCommand):
                 f"Model '{model_id}' does not require a credential, so it needs "
                 "no entry link. It is reachable through the normal flow."
             )
+        if not definition.is_active:
+            raise CommandError(
+                f"Model '{model_id}' is retired, so a link to it would be "
+                "refused on arrival. Nothing reaches a retired model."
+            )
 
         base_url = link_base_url()
         if base_url is None:

--- a/app/astrodash/management/commands/mint_model_link.py
+++ b/app/astrodash/management/commands/mint_model_link.py
@@ -1,0 +1,88 @@
+"""Mint a model-scoped entry link for a gated model.
+
+This command is the *only* way to produce an entry link: no URL route mints
+one, so a link can only come from an operator with shell access to a running
+deployment. The operator hands the printed link, plus the shared credential
+(which this command deliberately never prints), to whoever distributes them.
+"""
+
+from typing import Any
+
+from django.core.management.base import BaseCommand, CommandError
+from django.urls import reverse
+
+from astrodash.core.gate_config import LINK_BASE_URL_ENV_VAR, link_base_url
+from astrodash.core.model_access import GateNotConfigured, mint_entry_link
+from astrodash.infrastructure.ml.model_registry import get_definition
+
+
+class Command(BaseCommand):
+    """Print an entry link for one gated model."""
+
+    help = (
+        "Mint a model-scoped entry link for a gated model. The link expires, and "
+        "redeeming it still requires the shared access code, which this command "
+        "does not print."
+    )
+
+    def add_arguments(self, parser: Any) -> None:
+        """Declare the command's arguments.
+
+        Args:
+            parser: The argument parser supplied by Django.
+        """
+        parser.add_argument(
+            "model_id",
+            help="The id of the gated model the link should grant access to.",
+        )
+        parser.add_argument(
+            "--ttl-seconds",
+            type=int,
+            default=None,
+            help=(
+                "Override the configured expiry window, in seconds. The deadline "
+                "is stamped into the link when it is minted."
+            ),
+        )
+
+    def handle(self, *args: Any, **options: Any) -> None:
+        """Mint the link and print it.
+
+        Args:
+            *args: Unused positional arguments.
+            **options: Parsed command options.
+
+        Raises:
+            CommandError: If the model is unknown or not gated, if the link host
+                is unconfigured, or if the gate's own configuration is missing.
+        """
+        model_id = options["model_id"]
+        ttl_seconds = options["ttl_seconds"]
+
+        definition = get_definition(model_id)
+        if definition is None:
+            raise CommandError(f"No such model: '{model_id}'.")
+        if not definition.requires_credential:
+            raise CommandError(
+                f"Model '{model_id}' does not require a credential, so it needs "
+                "no entry link. It is reachable through the normal flow."
+            )
+
+        base_url = link_base_url()
+        if base_url is None:
+            raise CommandError(
+                f"{LINK_BASE_URL_ENV_VAR} is not configured. The application sits "
+                "behind a proxy, so the link host is configured rather than "
+                "inferred."
+            )
+
+        if ttl_seconds is not None and ttl_seconds <= 0:
+            raise CommandError("--ttl-seconds must be a positive number of seconds.")
+
+        try:
+            token = mint_entry_link(model_id, ttl_seconds=ttl_seconds)
+        except GateNotConfigured as exc:
+            raise CommandError(str(exc)) from exc
+
+        path = reverse("astrodash:model_gate", args=[token])
+        self.stdout.write(f"{base_url}{path}")

--- a/app/astrodash/surfaces.py
+++ b/app/astrodash/surfaces.py
@@ -26,6 +26,7 @@ from typing import Dict, FrozenSet, Optional, Sequence, Tuple
 from astrodash.infrastructure.ml.model_registry import (
     SURFACE_CLASSIFICATION,
     SURFACE_DASH_TWINS,
+    get_definition,
 )
 
 
@@ -79,6 +80,47 @@ SURFACES: Dict[str, Surface] = {
         routes=("dash_twins", "dash_twins_data", "twins_search"),
     ),
 }
+
+
+# A model the registry cannot resolve -- a user-uploaded model -- offers the
+# classification surface alone (KTD10). It never renders zero tabs.
+FALLBACK_SURFACE_IDS: Tuple[str, ...] = (SURFACE_CLASSIFICATION,)
+
+
+def declared_surfaces(model_type: Optional[str]) -> Tuple["Surface", ...]:
+    """Resolve the result surfaces a model declares, in declared order.
+
+    Args:
+        model_type: A model id as held in the session -- the *selected* model
+            for a surface the visitor merely browses, the *classified* model
+            for a surface reading a classification artifact (KTD5). May be
+            ``None`` or a value the registry cannot resolve.
+
+    Returns:
+        The declared :class:`Surface` entries, the first of which is the
+        default tab.
+    """
+    definition = get_definition(model_type) if model_type else None
+    surface_ids = (
+        definition.surfaces if definition is not None else FALLBACK_SURFACE_IDS
+    )
+    return resolve_surfaces(surface_ids)
+
+
+def offers_route(model_type: Optional[str], route_name: str) -> bool:
+    """Whether a model's declared surfaces own the given supporting route.
+
+    Args:
+        model_type: The model id that authorizes the route (see
+            :func:`declared_surfaces` for which one that is).
+        route_name: The route's name in the ``astrodash`` URL namespace.
+
+    Returns:
+        True when some declared surface lists the route as its own.
+    """
+    return any(
+        route_name in surface.routes for surface in declared_surfaces(model_type)
+    )
 
 
 def known_surface_ids() -> FrozenSet[str]:

--- a/app/astrodash/surfaces.py
+++ b/app/astrodash/surfaces.py
@@ -1,0 +1,130 @@
+"""The registry of result surfaces and how each one presents itself.
+
+A *result surface* is one tab in the classification result view, together with
+the supporting routes that tab owns. Every model definition declares the
+surfaces it offers as an ordered list of surface ids (see
+:mod:`astrodash.infrastructure.ml.model_registry`); this module is the single
+place an id is turned into something renderable -- its tab title, its pane
+identity, and its routes.
+
+The map lives here, in the web layer, rather than beside the definitions:
+nothing under ``astrodash.infrastructure`` imports Django or knows about URL
+names, so the definitions declare opaque ids and the registry's validator takes
+the set of known ids as an argument (see :func:`known_surface_ids`, called from
+the app-ready hook).
+
+Pane identity is a separate field from the surface id because the classification
+template's markup contract is rigid -- a tab is ``id="<slug>-tab"`` pointing at
+``href="#<slug>-pane"`` -- and its slugs predate these ids (the DASH Twins
+surface has always rendered as ``twins-tab`` / ``twins-pane``). Keeping the slug
+separate lets an id be named for what it is without renaming markup.
+"""
+
+from dataclasses import dataclass
+from typing import Dict, FrozenSet, Optional, Sequence, Tuple
+
+from astrodash.infrastructure.ml.model_registry import (
+    SURFACE_CLASSIFICATION,
+    SURFACE_DASH_TWINS,
+)
+
+
+@dataclass(frozen=True)
+class Surface:
+    """One result surface: a tab in the classification result view.
+
+    Attributes:
+        id: Stable surface identifier, as declared by a model definition.
+        title: Tab label as shown to the visitor (e.g. ``"DASH Twins"``).
+        pane: Markup slug for the tab and its pane. The template renders
+            ``id="<pane>-tab"``, ``href="#<pane>-pane"`` and
+            ``aria-controls="<pane>-pane"`` from it.
+        routes: Names of the supporting routes this surface owns, within the
+            ``astrodash`` URL namespace. Empty when the surface renders inline
+            in the classification view and owns no route of its own.
+    """
+
+    id: str
+    title: str
+    pane: str
+    routes: Tuple[str, ...] = ()
+
+    @property
+    def tab_id(self) -> str:
+        """DOM id of the tab anchor (``<pane>-tab``)."""
+        return f"{self.pane}-tab"
+
+    @property
+    def pane_id(self) -> str:
+        """DOM id of the tab pane (``<pane>-pane``), also its anchor target."""
+        return f"{self.pane}-pane"
+
+
+# Every known surface, keyed by id. Adding a surface is one entry here plus the
+# id constant the definitions declare -- no per-model conditional in the
+# classification template.
+SURFACES: Dict[str, Surface] = {
+    SURFACE_CLASSIFICATION: Surface(
+        id=SURFACE_CLASSIFICATION,
+        title="Classification",
+        pane="classification",
+        # The classification pane is rendered inline by the classify view
+        # itself, so it owns no supporting route of its own.
+        routes=(),
+    ),
+    SURFACE_DASH_TWINS: Surface(
+        id=SURFACE_DASH_TWINS,
+        title="DASH Twins",
+        pane="twins",
+        routes=("dash_twins", "dash_twins_data", "twins_search"),
+    ),
+}
+
+
+def known_surface_ids() -> FrozenSet[str]:
+    """Return the ids a model definition is allowed to declare.
+
+    Returns:
+        The set of every registered surface id. The app-ready hook passes this
+        to the registry's surface validator, which cannot import this module.
+    """
+    return frozenset(SURFACES)
+
+
+def get_surface(surface_id: str) -> Optional[Surface]:
+    """Resolve a surface id to its presentation.
+
+    Args:
+        surface_id: The declared surface identifier to look up.
+
+    Returns:
+        The matching :class:`Surface`, or ``None`` if no surface has that id.
+    """
+    return SURFACES.get(surface_id)
+
+
+def resolve_surfaces(surface_ids: Sequence[str]) -> Tuple[Surface, ...]:
+    """Resolve a declared surface list, preserving its order.
+
+    Args:
+        surface_ids: The ordered surface ids a model definition declares.
+
+    Returns:
+        The matching :class:`Surface` entries in the declared order; the first
+        is the surface that renders as the default tab.
+
+    Raises:
+        ValueError: If any id is not a known surface. Startup validation makes
+            this unreachable for the shipped registry, so it means a caller
+            passed something other than a validated declaration.
+    """
+    resolved = []
+    for surface_id in surface_ids:
+        surface = SURFACES.get(surface_id)
+        if surface is None:
+            raise ValueError(
+                f"Unknown result surface id: '{surface_id}'. "
+                f"Known surfaces: {sorted(SURFACES)}."
+            )
+        resolved.append(surface)
+    return tuple(resolved)

--- a/app/astrodash/templates/astrodash/batch.html
+++ b/app/astrodash/templates/astrodash/batch.html
@@ -67,12 +67,14 @@
                             </div>
                         </div>
                         <div class="row">
+                            {% if show_redshift_controls %}
                             <div class="col-md-4">
                                 {{ form.known_z|as_crispy_field }}
                             </div>
                             <div class="col-md-4">
                                 {{ form.redshift|as_crispy_field }}
                             </div>
+                            {% endif %}
                             <div class="col-md-4">
                                 {{ form.calculate_rlap|as_crispy_field }}
                             </div>

--- a/app/astrodash/templates/astrodash/classify.html
+++ b/app/astrodash/templates/astrodash/classify.html
@@ -52,10 +52,12 @@
                         {% csrf_token %}
 
                         {% if scoped_model_display %}
-                        {# A scoped session runs one model and cannot be moved
-                           to another, so the control is disabled and named.
-                           The hidden input keeps the field posted; the view
-                           takes the model from the scope regardless. #}
+                        {% comment %}
+                          A scoped session runs one model and cannot be moved
+                          to another, so the control is disabled and named.
+                          The hidden input keeps the field posted; the view
+                          takes the model from the scope regardless.
+                        {% endcomment %}
                         <input type="hidden" name="model" value="{{ scoped_model_type }}">
                         <div class="form-group">
                             <label class="form-label" for="scoped-model-name">Model</label>
@@ -117,9 +119,11 @@
                         </div>
                     </form>
                     {% if scoped_model_display %}
-                    {# Persistent, not only on a refused navigation: a reviewer
-                       who never leaves this page must still be able to end the
-                       session. Outside the form above, since forms cannot nest. #}
+                    {% comment %}
+                      Persistent, not only on a refused navigation: a reviewer
+                      who never leaves this page must still be able to end the
+                      session. Outside the form above, since forms cannot nest.
+                    {% endcomment %}
                     <hr>
                     <form method="post" action="{% url 'astrodash:end_model_scope' %}">
                         {% csrf_token %}

--- a/app/astrodash/templates/astrodash/classify.html
+++ b/app/astrodash/templates/astrodash/classify.html
@@ -116,6 +116,17 @@
                             <button type="button" class="btn btn-outline-secondary" onclick="clearForm()">Clear</button>
                         </div>
                     </form>
+                    {% if scoped_model_display %}
+                    {# Persistent, not only on a refused navigation: a reviewer
+                       who never leaves this page must still be able to end the
+                       session. Outside the form above, since forms cannot nest. #}
+                    <hr>
+                    <form method="post" action="{% url 'astrodash:end_model_scope' %}">
+                        {% csrf_token %}
+                        <button type="submit" class="btn btn-outline-secondary btn-sm btn-block" id="end-scope-button">End session</button>
+                        <p class="small text-muted mt-2 mb-0">Ends this session and discards everything it produced.</p>
+                    </form>
+                    {% endif %}
                 </div>
             </div>
         </div>

--- a/app/astrodash/templates/astrodash/classify.html
+++ b/app/astrodash/templates/astrodash/classify.html
@@ -22,20 +22,24 @@
         ">
         &larr;
     </a>
-    <!-- Tabs: Classification | DASH Twins -->
+    <!--
+      Tabs: one per result surface the selected model declares, in declared
+      order, the first being the default. The strip, the panes, and the
+      supporting-route guards all read the same list (astrodash/surfaces.py),
+      so a new surface is registered once and no conditional is keyed on a
+      model here.
+    -->
     <ul class="nav nav-tabs mb-3" id="classifyTabs" role="tablist">
+        {% for surface in result_surfaces %}
         <li class="nav-item" role="presentation">
-            <a class="nav-link active" id="classification-tab" data-toggle="tab" href="#classification-pane" role="tab" aria-controls="classification-pane" aria-selected="true">Classification</a>
+            <a class="nav-link{% if forloop.first %} active{% endif %}" id="{{ surface.tab_id }}" data-toggle="tab" href="#{{ surface.pane_id }}" role="tab" aria-controls="{{ surface.pane_id }}" aria-selected="{% if forloop.first %}true{% else %}false{% endif %}">{{ surface.title }}</a>
         </li>
-        {% if selected_model_type == 'dash' %}
-        <li class="nav-item" role="presentation">
-            <a class="nav-link" id="twins-tab" data-toggle="tab" href="#twins-pane" role="tab" aria-controls="twins-pane" aria-selected="false">DASH Twins</a>
-        </li>
-        {% endif %}
+        {% endfor %}
     </ul>
 
     <div class="tab-content" id="classifyTabContent">
-        <div class="tab-pane fade show active" id="classification-pane" role="tabpanel" aria-labelledby="classification-tab">
+        {% for surface in result_surfaces %}{% if surface.id == 'classification' %}
+        <div class="tab-pane fade{% if forloop.first %} show active{% endif %}" id="{{ surface.pane_id }}" role="tabpanel" aria-labelledby="{{ surface.tab_id }}">
     <div class="row">
         <!-- Sidebar: Input Form -->
         <div class="col-md-3">
@@ -113,7 +117,7 @@
                     <h4 class="mb-0">Spectrum Analysis</h4>
                     <div class="mt-2 mt-md-0">
                         <button type="button" class="btn btn-outline-primary btn-sm mr-2" id="customize-plot-btn" aria-label="Customize plot overlays">CUSTOMIZE PLOT</button>
-                        {% if selected_model_type == 'dash' and has_dash_embedding %}
+                        {% if 'dash_twins' in result_surface_ids and has_dash_embedding %}
                         <a href="#" class="btn btn-primary btn-sm mr-2" id="find-twins-btn" aria-label="Find twins in DASH embedding space">FIND TWINS</a>
                         {% endif %}
                         <button type="button" class="btn btn-outline-secondary btn-sm" id="save-plot-btn" aria-label="Save plot">SAVE</button>
@@ -272,12 +276,12 @@
         </div>
     </div>
         </div>
-        {% if selected_model_type == 'dash' %}
-        <!-- DASH Twins tab: embedded explorer -->
-        <div class="tab-pane fade" id="twins-pane" role="tabpanel" aria-labelledby="twins-tab">
+        {% elif surface.id == 'dash_twins' %}
+        <!-- DASH Twins pane: the embedded explorer, its own supporting routes. -->
+        <div class="tab-pane fade{% if forloop.first %} show active{% endif %}" id="{{ surface.pane_id }}" role="tabpanel" aria-labelledby="{{ surface.tab_id }}">
             <iframe id="dash-twins-iframe" src="{% url 'astrodash:dash_twins' %}" title="DASH Twins Explorer" style="width: 100%; height: calc(100vh - 180px); min-height: 600px; border: 1px solid #dee2e6; border-radius: 4px;"></iframe>
         </div>
-        {% endif %}
+        {% endif %}{% endfor %}
     </div>
 </div>
 

--- a/app/astrodash/templates/astrodash/classify.html
+++ b/app/astrodash/templates/astrodash/classify.html
@@ -51,7 +51,18 @@
                     <form method="post" enctype="multipart/form-data">
                         {% csrf_token %}
 
-                        {% if selected_model_display %}
+                        {% if scoped_model_display %}
+                        {# A scoped session runs one model and cannot be moved
+                           to another, so the control is disabled and named.
+                           The hidden input keeps the field posted; the view
+                           takes the model from the scope regardless. #}
+                        <input type="hidden" name="model" value="{{ scoped_model_type }}">
+                        <div class="form-group">
+                            <label class="form-label" for="scoped-model-name">Model</label>
+                            <input type="text" class="form-control font-weight-bold" id="scoped-model-name" value="{{ scoped_model_display }}" disabled>
+                            <p class="small text-muted mt-2">This session is limited to this model.</p>
+                        </div>
+                        {% elif selected_model_display %}
                         <input type="hidden" name="model" value="user_uploaded">
                         <div class="form-group">
                             <label class="form-label">Model</label>

--- a/app/astrodash/templates/astrodash/classify.html
+++ b/app/astrodash/templates/astrodash/classify.html
@@ -87,12 +87,14 @@
                                 {{ form.max_wave|as_crispy_field }}
                             </div>
                         </div>
+                        {% if show_redshift_controls %}
                         <div class="form-group">
                             {{ form.known_z|as_crispy_field }}
                         </div>
                         <div class="form-group">
                             {{ form.redshift|as_crispy_field }}
                         </div>
+                        {% endif %}
 
                         <div class="d-flex justify-content-between mt-3">
                             <button type="submit" class="btn btn-primary flex-grow-1 mr-2">Classify</button>

--- a/app/astrodash/templates/astrodash/model_gate.html
+++ b/app/astrodash/templates/astrodash/model_gate.html
@@ -1,12 +1,12 @@
 {% extends "astrodash/base.html" %}
 
-{#
+{% comment %}
   The shared-credential prompt an entry link leads to.
 
   Copy names no model: a visitor who reaches this page without the credential
   must learn nothing about which model the link points at, or that any
   particular model exists.
-#}
+{% endcomment %}
 
 {% block content %}
 <div class="container mt-5" style="max-width: 460px;">

--- a/app/astrodash/templates/astrodash/model_gate.html
+++ b/app/astrodash/templates/astrodash/model_gate.html
@@ -1,0 +1,44 @@
+{% extends "astrodash/base.html" %}
+
+{#
+  The shared-credential prompt an entry link leads to.
+
+  Copy names no model: a visitor who reaches this page without the credential
+  must learn nothing about which model the link points at, or that any
+  particular model exists.
+#}
+
+{% block content %}
+<div class="container mt-5" style="max-width: 460px;">
+    <div class="card shadow-sm">
+        <div class="card-header bg-dark text-white">
+            <h5 class="mb-0">Access code required</h5>
+        </div>
+        <div class="card-body">
+            <p class="text-muted">
+                This link opens a model that is not yet publicly available. Enter the
+                access code you were given along with the link.
+            </p>
+            {% if credential_error %}
+            <div class="alert alert-danger" role="alert" id="model-gate-error">
+                {{ credential_error }}
+            </div>
+            {% endif %}
+            <form method="post">
+                {% csrf_token %}
+                <div class="form-group">
+                    <label for="model-gate-credential">Access code</label>
+                    <input type="password"
+                           class="form-control"
+                           id="model-gate-credential"
+                           name="credential"
+                           autocomplete="off"
+                           autofocus
+                           required>
+                </div>
+                <button type="submit" class="btn btn-primary btn-block">Continue</button>
+            </form>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/app/astrodash/templates/astrodash/model_gate_refused.html
+++ b/app/astrodash/templates/astrodash/model_gate_refused.html
@@ -1,0 +1,27 @@
+{% extends "astrodash/base.html" %}
+
+{#
+  Shown whenever an entry link does not grant access -- expired, malformed, or
+  tampered with -- and whenever a scope ends.
+
+  The default copy is disclosure-minimal and names no model: an anonymous
+  reviewer arriving on a cold link may see this before anything else, and it
+  must not confirm that any particular model exists. A caller that already
+  knows the visitor is inside the window (a lapsed scope, say) can pass its own
+  heading and message.
+#}
+
+{% block content %}
+<div class="container mt-5" style="max-width: 520px;">
+    <div class="card shadow-sm" id="model-gate-refused">
+        <div class="card-header bg-dark text-white">
+            <h5 class="mb-0">{{ refusal_heading|default:"This link is not available" }}</h5>
+        </div>
+        <div class="card-body">
+            <p class="mb-0">
+                {{ refusal_message|default:"This link is no longer valid. If you were given it and still need access, ask whoever sent it to you." }}
+            </p>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/app/astrodash/templates/astrodash/model_gate_refused.html
+++ b/app/astrodash/templates/astrodash/model_gate_refused.html
@@ -1,6 +1,6 @@
 {% extends "astrodash/base.html" %}
 
-{#
+{% comment %}
   Shown whenever an entry link does not grant access -- expired, malformed, or
   tampered with -- and whenever a scope ends.
 
@@ -9,7 +9,7 @@
   must not confirm that any particular model exists. A caller that already
   knows the visitor is inside the window (a lapsed scope, say) can pass its own
   heading and message.
-#}
+{% endcomment %}
 
 {% block content %}
 <div class="container mt-5" style="max-width: 520px;">

--- a/app/astrodash/tests/gate_fixtures.py
+++ b/app/astrodash/tests/gate_fixtures.py
@@ -132,6 +132,29 @@ def classify_post(model: str) -> dict:
     }
 
 
+def redeem_scope(client, test_case, now=1000.0, ttl_seconds="3600", model_id="dash"):
+    """Establish a scope on a test client by redeeming a fresh entry link.
+
+    Args:
+        client: The Django test client to scope.
+        test_case: The calling ``TestCase``, used to assert the redemption
+            actually succeeded rather than silently leaving the client unscoped.
+        now: The POSIX timestamp to mint and redeem at.
+        ttl_seconds: The configured expiry window.
+        model_id: The built-in id to gate and scope to.
+
+    Returns:
+        float: The absolute deadline the scope was granted with.
+    """
+    with gated_gate(model_id, ttl_seconds=ttl_seconds), patch.object(
+        model_access, "_now", return_value=now
+    ):
+        token = model_access.mint_entry_link(model_id)
+        response = client.post(gate_url(token), data={"credential": GATE_CREDENTIAL})
+    test_case.assertEqual(response.status_code, 302)
+    return client.session[model_access.SCOPE_DEADLINE_KEY]
+
+
 @contextmanager
 def mocked_classification(model_type: str):
     """Run the classify view without model weights or network access.

--- a/app/astrodash/tests/gate_fixtures.py
+++ b/app/astrodash/tests/gate_fixtures.py
@@ -1,0 +1,171 @@
+"""Shared fixtures for the gated-model access gate.
+
+The shipped roster contains no gated model -- that is the point of the
+capability, not an oversight -- so every test that needs one builds it here:
+``dataclasses.replace`` over a real definition plus a patched roster (KTD9).
+A fixture built this way never passes through the import-time validators, so a
+test that wants to exercise an invariant calls the validator directly rather
+than reloading modules.
+
+The gate's deployment values are patched in the same way, and the classify view
+is driven with its services mocked, so nothing here needs model weights, network
+access, or a configured deployment.
+"""
+
+import os
+from contextlib import contextmanager
+from dataclasses import replace
+from typing import Optional, Tuple
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from django.http import HttpResponse
+from django.urls import reverse
+
+from astrodash.core import gate_config, model_access
+from astrodash.infrastructure.ml import model_registry
+from astrodash.infrastructure.ml.model_registry import ModelDefinition
+
+# The gate configuration every test runs against. Neither the credential nor the
+# signing key may be blank or carry the committed ``django-insecure-`` prefix,
+# or the gate reads them as unconfigured and fails closed.
+GATE_CREDENTIAL = "review-window-access-code"
+GATE_SIGNING_KEY = "test-entry-link-signing-key"
+GATE_LINK_BASE_URL = "https://astrodash-dev.example.org"
+
+
+def gated_roster(model_id: str = "dash") -> Tuple[ModelDefinition, ...]:
+    """Return a roster in which one built-in model is gated.
+
+    Args:
+        model_id: The built-in id to gate. It is made unlisted at the same
+            time, because the registry forbids a gated model from being listed.
+
+    Returns:
+        A ``MODELS``-shaped tuple suitable for ``patch.object``.
+    """
+    return tuple(
+        replace(m, listed=False, requires_credential=True) if m.id == model_id else m
+        for m in model_registry.MODELS
+    )
+
+
+@contextmanager
+def gate_configured(
+    credential: Optional[str] = GATE_CREDENTIAL,
+    ttl_seconds: Optional[str] = "3600",
+    signing_key: Optional[str] = GATE_SIGNING_KEY,
+):
+    """Configure the gate's deployment values for the duration of the block.
+
+    The normalized configuration is patched in rather than driven through the
+    environment, because the entry-link signing key *is* ``SECRET_KEY``: moving
+    the real setting would re-sign the test client's session cookie mid-test and
+    every session assertion would then read an empty session instead of the one
+    the gate wrote. ``gate_config``'s own normalization is covered by the
+    registry tests. The link host is a separate value that no session depends
+    on, so it stays an environment read.
+
+    Args:
+        credential: The shared credential an operator would configure.
+        ttl_seconds: The entry-link expiry window, as an operator sets it.
+        signing_key: The key entry links are signed with.
+
+    Yields:
+        None.
+    """
+    configuration = {
+        gate_config.CREDENTIAL_ENV_VAR: credential,
+        gate_config.LINK_TTL_ENV_VAR: ttl_seconds,
+        gate_config.SIGNING_KEY_NAME: signing_key,
+    }
+    with patch.object(
+        model_access, "gate_configuration", return_value=configuration
+    ), patch.dict(os.environ, {gate_config.LINK_BASE_URL_ENV_VAR: GATE_LINK_BASE_URL}):
+        yield
+
+
+@contextmanager
+def gated_gate(model_id: str = "dash", **config):
+    """Patch in a gated roster *and* the gate configuration together.
+
+    Args:
+        model_id: The built-in id to gate.
+        **config: Passed through to :func:`gate_configured`.
+
+    Yields:
+        None.
+    """
+    with patch.object(model_registry, "MODELS", gated_roster(model_id)):
+        with gate_configured(**config):
+            yield
+
+
+def gate_url(token: str) -> str:
+    """Return the entry-link path carrying a token.
+
+    Args:
+        token: The signed entry-link token.
+
+    Returns:
+        The path an entry link resolves to.
+    """
+    return reverse("astrodash:model_gate", args=[token])
+
+
+def classify_post(model: str) -> dict:
+    """Return a valid classify-form payload naming a model.
+
+    Args:
+        model: The value to put in the form's model field. Inside a scoped flow
+            this is exactly the field an attacker would alter, so tests vary it
+            independently of the scope.
+
+    Returns:
+        The POST data.
+    """
+    return {
+        "supernova_name": "SN2011fe",
+        "model": model,
+        "smoothing": 0,
+        "min_wave": 3500,
+        "max_wave": 10000,
+    }
+
+
+@contextmanager
+def mocked_classification(model_type: str):
+    """Run the classify view without model weights or network access.
+
+    Args:
+        model_type: The model the mocked classification reports having run.
+
+    Yields:
+        The mocked classification service, so a test can read back which model
+        the view actually asked it to run.
+    """
+    processed = MagicMock()
+    processed.x = [3000.0, 5000.0, 9000.0]
+    processed.y = [1.0, 2.0, 1.0]
+
+    classification = MagicMock()
+    classification.model_type = model_type
+    classification.results = {"best_matches": [], "embedding": [0.0] * 1024}
+
+    classification_svc = MagicMock(
+        classify_spectrum=AsyncMock(return_value=classification)
+    )
+    with patch(
+        "astrodash.ui_views.get_spectrum_service",
+        return_value=MagicMock(get_spectrum_data=AsyncMock(return_value=MagicMock())),
+    ), patch(
+        "astrodash.ui_views.get_spectrum_processing_service",
+        return_value=MagicMock(
+            process_spectrum_with_params=AsyncMock(return_value=processed)
+        ),
+    ), patch(
+        "astrodash.ui_views.get_classification_service",
+        return_value=classification_svc,
+    ), patch(
+        "astrodash.ui_views.render", return_value=HttpResponse(b"")
+    ):
+        yield classification_svc

--- a/app/astrodash/tests/test_api_model_type.py
+++ b/app/astrodash/tests/test_api_model_type.py
@@ -26,6 +26,51 @@ from django.urls import reverse
 from astrodash.infrastructure.ml import model_registry
 
 
+def _gated_roster():
+    """Roster where DASH is gated: active, unlisted, credential-required.
+
+    Transformer is left untouched so it remains the listed, ungated active
+    default the registry invariants require.
+
+    Returns:
+        A ``MODELS``-shaped tuple suitable for ``patch.object``.
+    """
+    transformer = model_registry.get_definition("transformer")
+    dash = model_registry.get_definition("dash")
+    return (transformer, replace(dash, listed=False, requires_credential=True))
+
+
+def _absent_roster():
+    """Roster from which DASH is missing entirely, so its id is unknown.
+
+    Returns:
+        A ``MODELS``-shaped tuple containing only Transformer.
+    """
+    return (model_registry.get_definition("transformer"),)
+
+
+def _retired_roster():
+    """Roster where DASH is retired but still resolvable by id.
+
+    Returns:
+        A ``MODELS``-shaped tuple suitable for ``patch.object``.
+    """
+    transformer = model_registry.get_definition("transformer")
+    dash = model_registry.get_definition("dash")
+    return (transformer, replace(dash, status=model_registry.STATUS_RETIRED))
+
+
+def _unlisted_ungated_roster():
+    """Roster where DASH is active and ungated but not listed.
+
+    Returns:
+        A ``MODELS``-shaped tuple suitable for ``patch.object``.
+    """
+    transformer = model_registry.get_definition("transformer")
+    dash = model_registry.get_definition("dash")
+    return (transformer, replace(dash, listed=False))
+
+
 def _mock_classification(model_type):
     """Build a fake classification result the classify payload can serialize."""
     fake_processed = MagicMock()
@@ -132,6 +177,56 @@ class ClassifyModelTypeContractTests(SimpleTestCase):
         self.assertEqual(resp.status_code, 400)
         self.assertEqual(resp.json()["detail"], "Unknown model type: user_uploaded.")
 
+    # --- gated models (R25 / AE9) ---
+
+    def test_gated_model_type_returns_400(self):
+        """AE9: a credential-gated model is refused even with writes enabled."""
+        spectrum_svc, processing_svc, classification_svc = _mock_classification("dash")
+        with patch.object(model_registry, "MODELS", _gated_roster()), patch(
+            "astrodash.views.API_WRITES_ENABLED", True
+        ), patch(
+            "astrodash.views.get_classification_service",
+            return_value=classification_svc,
+        ):
+            resp = self.client.post(self.url, data={"params": '{"modelType": "dash"}'})
+        self.assertEqual(resp.status_code, 400)
+        classification_svc.classify_spectrum.assert_not_called()
+
+    def test_gated_rejection_is_indistinguishable_from_unknown(self):
+        """AE9: gated and unknown refusals match; retired stays distinct.
+
+        All three requests name the same id, so a caller cannot use the
+        endpoint to learn whether an unreleased model exists.
+        """
+        params = '{"modelType": "dash"}'
+        with patch.object(model_registry, "MODELS", _gated_roster()):
+            gated = self._post(data={"params": params})
+        with patch.object(model_registry, "MODELS", _absent_roster()):
+            unknown = self._post(data={"params": params})
+        with patch.object(model_registry, "MODELS", _retired_roster()):
+            retired = self._post(data={"params": params})
+
+        self.assertEqual(gated.status_code, unknown.status_code)
+        self.assertEqual(gated.content, unknown.content)
+        self.assertNotEqual(gated.content, retired.content)
+        self.assertEqual(retired.status_code, 400)
+        self.assertEqual(retired.json()["detail"], "Model type dash is not available.")
+
+    def test_unlisted_ungated_model_remains_resolvable(self):
+        """R27: listing is presentation, so an ungated unlisted model still runs."""
+        with patch.object(model_registry, "MODELS", _unlisted_ungated_roster()):
+            resp, classification_svc = self._post_with_services(
+                {
+                    "params": '{"modelType": "dash"}',
+                    "_expected_model_type": "dash",
+                }
+            )
+        self.assertEqual(resp.status_code, 200)
+        classification_svc.classify_spectrum.assert_called_once()
+        self.assertEqual(
+            classification_svc.classify_spectrum.call_args.kwargs["model_type"], "dash"
+        )
+
     # --- unchanged paths (parity) ---
 
     def test_valid_transformer_classifies_as_today(self):
@@ -228,6 +323,35 @@ class BatchModelTypeContractTests(SimpleTestCase):
             resp.json()["detail"], "Model type transformer is not available."
         )
         batch_svc.process_batch.assert_not_called()
+
+    def test_gated_model_type_returns_400(self):
+        """AE9: the batch endpoint refuses a gated model too."""
+        with patch.object(model_registry, "MODELS", _gated_roster()):
+            resp, batch_svc = self._post(params='{"modelType": "dash"}')
+        self.assertEqual(resp.status_code, 400)
+        batch_svc.process_batch.assert_not_called()
+
+    def test_gated_rejection_is_indistinguishable_from_unknown(self):
+        """AE9: gated and unknown refusals match on the batch endpoint too."""
+        params = '{"modelType": "dash"}'
+        with patch.object(model_registry, "MODELS", _gated_roster()):
+            gated, _ = self._post(params=params)
+        with patch.object(model_registry, "MODELS", _absent_roster()):
+            unknown, _ = self._post(params=params)
+        with patch.object(model_registry, "MODELS", _retired_roster()):
+            retired, _ = self._post(params=params)
+
+        self.assertEqual(gated.status_code, unknown.status_code)
+        self.assertEqual(gated.content, unknown.content)
+        self.assertNotEqual(gated.content, retired.content)
+
+    def test_unlisted_ungated_model_remains_resolvable(self):
+        """R27: an unlisted but ungated model still reaches the batch service."""
+        with patch.object(model_registry, "MODELS", _unlisted_ungated_roster()):
+            resp, batch_svc = self._post(params='{"modelType": "dash"}')
+        self.assertEqual(resp.status_code, 200)
+        batch_svc.process_batch.assert_called_once()
+        self.assertEqual(batch_svc.process_batch.call_args.args[2], "dash")
 
     def test_valid_dash_reaches_batch_service(self):
         resp, batch_svc = self._post(params='{"modelType": "dash"}')

--- a/app/astrodash/tests/test_classifier_parity.py
+++ b/app/astrodash/tests/test_classifier_parity.py
@@ -11,15 +11,20 @@ exercised by driving the classify view with the spectrum/processing/
 classification services mocked, so no weights or network access are needed.
 """
 
+import json
 import re
+import tempfile
 from contextlib import nullcontext
 from dataclasses import replace
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from asgiref.sync import async_to_sync
+from django.core.signals import request_finished
+from django.db import close_old_connections
 from django.http import HttpResponse
-from django.test import Client, TestCase
+from django.test import Client, SimpleTestCase, TestCase
 from django.urls import reverse
 
 from astrodash.forms import ClassifyForm, ModelSelectionForm
@@ -638,3 +643,264 @@ class ClassifyViewGateParityTests(TestCase):
         session = self._run_classify("transformer")
         self.assertNotIn("classify_dash_embedding", session)
         self.assertFalse(session.get("classify_show_templates_section"))
+
+
+class ResultSurfaceRenderingTests(TestCase):
+    """R17/R20/AE7: the tab strip and panes come from the declared list.
+
+    Per KTD5 the strip renders from the *selected* model, not the classified
+    one: today a DASH-selected page shows the DASH Twins tab before any
+    classification has run, and that must stay true. Every test here therefore
+    drives a session with a selection and no classification artifacts at all.
+    """
+
+    CLASSIFICATION_TAB = 'id="classification-tab"'
+    CLASSIFICATION_PANE = 'id="classification-pane"'
+    TWINS_TAB = 'id="twins-tab"'
+    TWINS_PANE = 'id="twins-pane"'
+
+    def _render_visible(self, model_type):
+        """GET the classify page with a model selected and nothing classified.
+
+        Args:
+            model_type: The value to place in the session as the selected model.
+
+        Returns:
+            str: The rendered HTML with ``<!-- ... -->`` comments removed.
+        """
+        session = self.client.session
+        session["selected_model_type"] = model_type
+        if model_type == "user_uploaded":
+            session["selected_model_id"] = "user-model-1"
+        session.save()
+
+        model_svc = MagicMock(
+            get_model=AsyncMock(return_value=SimpleNamespace(name="My uploaded model"))
+        )
+        with patch("astrodash.ui_views.get_model_service", return_value=model_svc):
+            resp = self.client.get(reverse("astrodash:classify"))
+        self.assertEqual(resp.status_code, 200)
+        return re.sub(r"<!--.*?-->", "", resp.content.decode(), flags=re.DOTALL)
+
+    @staticmethod
+    def _tag_with_id(html, dom_id):
+        """Return the opening tag carrying ``id="<dom_id>"``, or ``None``."""
+        match = re.search(r"<[a-z]+[^>]*\bid=\"%s\"[^>]*>" % re.escape(dom_id), html)
+        return match.group(0) if match else None
+
+    def test_dash_renders_both_tabs_in_declared_order_before_any_classification(self):
+        """AE7: DASH offers Classification then DASH Twins, pre-classification."""
+        html = self._render_visible("dash")
+        self.assertIn(self.CLASSIFICATION_TAB, html)
+        self.assertIn(self.TWINS_TAB, html)
+        self.assertIn("DASH Twins", html)
+        # Declared order: Classification first, DASH Twins second.
+        self.assertLess(html.index(self.CLASSIFICATION_TAB), html.index(self.TWINS_TAB))
+
+    def test_dash_renders_both_panes_wired_to_their_tabs(self):
+        html = self._render_visible("dash")
+        for tab, pane in (
+            (self.CLASSIFICATION_TAB, "classification-pane"),
+            (self.TWINS_TAB, "twins-pane"),
+        ):
+            with self.subTest(tab=tab):
+                anchor = self._tag_with_id(html, tab.split('"')[1])
+                self.assertIsNotNone(anchor)
+                self.assertIn(f'href="#{pane}"', anchor)
+                self.assertIn(f'aria-controls="{pane}"', anchor)
+                self.assertIsNotNone(self._tag_with_id(html, pane))
+
+    def test_first_declared_surface_is_the_active_tab_and_pane(self):
+        """R17: the first declared surface is the default, the rest are not."""
+        html = self._render_visible("dash")
+        classification_tab = self._tag_with_id(html, "classification-tab")
+        twins_tab = self._tag_with_id(html, "twins-tab")
+        self.assertIn("active", classification_tab)
+        self.assertIn('aria-selected="true"', classification_tab)
+        self.assertNotIn("active", twins_tab)
+        self.assertIn('aria-selected="false"', twins_tab)
+
+        classification_pane = self._tag_with_id(html, "classification-pane")
+        twins_pane = self._tag_with_id(html, "twins-pane")
+        self.assertIn("show active", classification_pane)
+        self.assertNotIn("show active", twins_pane)
+
+    def test_transformer_renders_only_the_classification_tab(self):
+        """AE7: Transformer declares Classification only, so no twins tab."""
+        html = self._render_visible("transformer")
+        self.assertIn(self.CLASSIFICATION_TAB, html)
+        self.assertNotIn(self.TWINS_TAB, html)
+        self.assertNotIn(self.TWINS_PANE, html)
+        self.assertNotIn("DASH Twins", html)
+        self.assertIn("show active", self._tag_with_id(html, "classification-pane"))
+
+    def test_user_uploaded_selection_renders_only_the_classification_tab(self):
+        """KTD10: an unresolvable selection falls back to Classification alone."""
+        html = self._render_visible("user_uploaded")
+        self.assertIn(self.CLASSIFICATION_TAB, html)
+        self.assertNotIn(self.TWINS_TAB, html)
+        self.assertNotIn(self.TWINS_PANE, html)
+        self.assertIn("show active", self._tag_with_id(html, "classification-pane"))
+
+    def test_classification_pane_content_still_renders(self):
+        """R21: moving the pane under the loop must not drop its markup."""
+        html = self._render_visible("dash")
+        self.assertIn('id="id_smoothing"', html)
+        self.assertIn("Input Parameters", html)
+
+
+class ClassifyTemplateLiteralGuardTests(SimpleTestCase):
+    """R20/R22: no per-model conditional survives in the classify template."""
+
+    TEMPLATE = (
+        Path(__file__).resolve().parent.parent
+        / "templates"
+        / "astrodash"
+        / "classify.html"
+    )
+
+    # A conditional comparison against a quoted built-in model id, in either
+    # order, mirroring ``test_no_model_type_literals.py``'s guard.
+    PATTERN = re.compile(
+        r"""(?:==|!=)\s*(?P<q1>['"])(?:dash|transformer|user_uploaded)(?P=q1)"""
+        r"""|(?P<q2>['"])(?:dash|transformer|user_uploaded)(?P=q2)\s*(?:==|!=)"""
+    )
+
+    def test_no_per_model_conditional_in_the_classification_template(self):
+        offenders = [
+            f"  classify.html:{lineno}: {line.strip()}"
+            for lineno, line in enumerate(
+                self.TEMPLATE.read_text(encoding="utf-8").splitlines(), start=1
+            )
+            if self.PATTERN.search(line)
+        ]
+        self.assertFalse(
+            offenders,
+            "Found per-model conditionals in the classification template. "
+            "Result surfaces render from the selected model's declared "
+            "surface list, so no tab, pane, or control may be keyed on a "
+            "model id:\n" + "\n".join(offenders),
+        )
+
+
+class TwinsSupportingRouteGuardTests(TestCase):
+    """R19/AE6: an undeclared surface's routes are unreachable, not just hidden.
+
+    KTD5 splits the authority by route. ``twins_search`` reads the embedding a
+    classification stashed, so it authorizes from the *classified* model. The
+    twins page and its data route serve a model-agnostic payload with no
+    session dependency, so they authorize from the *selected* model -- which is
+    what keeps them reachable before any classification has run, exactly as
+    today.
+    """
+
+    EMBEDDING = [0.0] * 1024
+
+    def _session(self, selected=None, classified=None, embedding=False):
+        """Seed the session with a selection, a classification, or both."""
+        session = self.client.session
+        if selected is not None:
+            session["selected_model_type"] = selected
+        if classified is not None:
+            session["classify_model_type"] = classified
+        if embedding:
+            session["classify_dash_embedding"] = list(self.EMBEDDING)
+        session.save()
+
+    @staticmethod
+    def _payload_config(tmpdir):
+        """Write a twins payload under a temp data dir and return a config."""
+        explorer = Path(tmpdir) / "explorer"
+        explorer.mkdir(parents=True, exist_ok=True)
+        (explorer / "dash_twins_payload.json").write_text(json.dumps({"points": []}))
+        return SimpleNamespace(data_dir=str(tmpdir))
+
+    @staticmethod
+    def _drain(response):
+        """Consume a streaming response without closing this test's connection.
+
+        The test client wires ``response.close`` into the streaming iterator,
+        and that close fires ``request_finished`` -> ``close_old_connections``,
+        which would tear down the connection the test's transaction runs in and
+        break every test after it. Django disconnects that receiver around
+        ``close()`` for non-streaming responses; do the same here.
+
+        Args:
+            response: The streaming response to consume.
+
+        Returns:
+            bytes: The response body.
+        """
+        request_finished.disconnect(close_old_connections)
+        try:
+            return b"".join(response.streaming_content)
+        finally:
+            request_finished.connect(close_old_connections)
+
+    # --- twins_search: authorized from the CLASSIFIED model ---
+
+    def test_twins_search_refused_after_a_transformer_classification(self):
+        """AE6: refused even though a stale embedding sits in the session."""
+        self._session(selected="transformer", classified="transformer", embedding=True)
+        svc = MagicMock()
+        with patch("astrodash.ui_views.get_twins_search_service", return_value=svc):
+            resp = self.client.get(reverse("astrodash:twins_search"))
+        self.assertEqual(resp.status_code, 403)
+        svc.find_twins.assert_not_called()
+
+    def test_twins_search_served_after_a_dash_classification(self):
+        self._session(selected="dash", classified="dash", embedding=True)
+        svc = MagicMock(
+            find_twins=MagicMock(
+                return_value={
+                    "query_umap": [0.0, 0.0],
+                    "twin_indices": [1],
+                    "twin_similarities": [0.9],
+                }
+            )
+        )
+        with patch("astrodash.ui_views.get_twins_search_service", return_value=svc):
+            resp = self.client.get(reverse("astrodash:twins_search"))
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()["twin_indices"], [1])
+
+    # --- twins page and data: authorized from the SELECTED model ---
+
+    def test_dash_selection_reaches_both_twins_routes_before_any_classification(self):
+        """R21: the pre-classification twins pane keeps working exactly as today."""
+        self._session(selected="dash")
+        page = self.client.get(reverse("astrodash:dash_twins"))
+        self.assertEqual(page.status_code, 200)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch(
+                "astrodash.ui_views.get_config",
+                return_value=self._payload_config(tmpdir),
+            ):
+                data = self.client.get(reverse("astrodash:dash_twins_data"))
+                self.assertEqual(data.status_code, 200)
+                self.assertEqual(json.loads(self._drain(data)), {"points": []})
+
+    def test_transformer_selection_is_refused_both_twins_routes(self):
+        self._session(selected="transformer")
+        self.assertEqual(
+            self.client.get(reverse("astrodash:dash_twins")).status_code, 403
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch(
+                "astrodash.ui_views.get_config",
+                return_value=self._payload_config(tmpdir),
+            ):
+                resp = self.client.get(reverse("astrodash:dash_twins_data"))
+        self.assertEqual(resp.status_code, 403)
+
+    def test_twins_page_is_not_gated_on_the_classified_model(self):
+        """KTD5: a DASH selection whose last run was Transformer still browses.
+
+        The page carries no classification artifact, so the classified model
+        must not decide it -- only the selection does.
+        """
+        self._session(selected="dash", classified="transformer")
+        self.assertEqual(
+            self.client.get(reverse("astrodash:dash_twins")).status_code, 200
+        )

--- a/app/astrodash/tests/test_classifier_parity.py
+++ b/app/astrodash/tests/test_classifier_parity.py
@@ -12,6 +12,7 @@ classification services mocked, so no weights or network access are needed.
 """
 
 import re
+from contextlib import nullcontext
 from dataclasses import replace
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -211,11 +212,17 @@ class ClassifyFormRedshiftParityTests(TestCase):
         self.assertFalse(form.is_valid())
         self.assertIn("redshift", form.errors)
         self.assertTrue(
-            any(
-                "Redshift is required for Transformer" in e
-                for e in form.errors["redshift"]
-            )
+            any("Redshift is required" in e for e in form.errors["redshift"])
         )
+
+    def test_required_redshift_message_names_no_model(self):
+        """R13: the message follows the policy, so it names no model literally."""
+        form = ClassifyForm(data=self._base_data("transformer"))
+        self.assertFalse(form.is_valid())
+        for error in form.errors["redshift"]:
+            self.assertNotIn("Transformer", error)
+            self.assertNotIn("transformer", error)
+            self.assertNotIn("Dash", error)
 
     def test_dash_does_not_require_redshift(self):
         form = ClassifyForm(data=self._base_data("dash"))
@@ -359,16 +366,211 @@ class BatchRedshiftGateParityTests(TestCase):
         self.assertIn("redshift", resp.context["form"].errors)
         self.assertTrue(
             any(
-                "Redshift is required for Transformer" in e
+                "Redshift is required" in e
                 for e in resp.context["form"].errors["redshift"]
             )
         )
+
+    def test_batch_required_redshift_message_names_no_model(self):
+        """R13: the batch gate's message follows the policy, naming no model."""
+        resp = self._post_batch("transformer")
+        for error in resp.context["form"].errors["redshift"]:
+            self.assertNotIn("Transformer", error)
+            self.assertNotIn("transformer", error)
+            self.assertNotIn("Dash", error)
 
     def test_dash_batch_does_not_require_redshift(self):
         resp = self._post_batch("dash")
         self.assertEqual(resp.status_code, 200)
         # DASH does not require a redshift, so the gate adds no redshift error
         # (the request instead falls through to the "no files uploaded" path).
+        self.assertNotIn("redshift", resp.context["form"].errors)
+
+
+class RedshiftInputPolicyFlowTests(TestCase):
+    """R13/R14/AE4: the three-way redshift input policy governs both UI flows.
+
+    A model declaring :data:`REDSHIFT_INPUT_NONE` takes no redshift at all, so
+    neither the redshift field nor the Known Redshift checkbox may render, and
+    a submission without a redshift must validate -- in the classification flow
+    and the batch flow alike, which run through two independent gates (the
+    classify form's ``clean`` and the batch view's own check).
+
+    DASH is the model whose policy is varied, following the registry fixture
+    idiom of ``dataclasses.replace`` over a patched roster; Transformer is left
+    untouched so it keeps satisfying the registry invariants and doubles as the
+    unchanged control.
+    """
+
+    # Markers for the two controls as crispy renders them.
+    REDSHIFT_FIELD_MARKER = 'id="id_redshift"'
+    KNOWN_Z_FIELD_MARKER = 'id="id_known_z"'
+
+    def _roster(self, policy):
+        """Return a roster where DASH declares the given redshift input policy.
+
+        Args:
+            policy: One of the ``REDSHIFT_INPUT_*`` constants.
+
+        Returns:
+            tuple: A ``MODELS``-shaped tuple suitable for ``patch.object``.
+        """
+        transformer = model_registry.get_definition("transformer")
+        dash = model_registry.get_definition("dash")
+        return (transformer, replace(dash, redshift_input=policy))
+
+    def _base_classify_data(self, model):
+        return {
+            "supernova_name": "SN2011fe",
+            "model": model,
+            "smoothing": 0,
+            "min_wave": 3500,
+            "max_wave": 10000,
+        }
+
+    def _render_visible(self, url_name, model_type, roster=None):
+        """GET a flow's page with a model selected and return its visible HTML.
+
+        Args:
+            url_name: The URL name to reverse (``astrodash:classify`` or
+                ``astrodash:batch_process_ui``).
+            model_type: The value to place in the session as the selected model.
+            roster: Optional ``MODELS``-shaped tuple to patch in for the request.
+
+        Returns:
+            str: The rendered HTML with ``<!-- ... -->`` comments removed, so
+            assertions see only what actually renders.
+        """
+        session = self.client.session
+        session["selected_model_type"] = model_type
+        if model_type == "user_uploaded":
+            session["selected_model_id"] = "user-model-1"
+        session.save()
+
+        # The classify view resolves a display name for a user-uploaded model;
+        # mock the service so no DB/filesystem work happens.
+        model_svc = MagicMock(
+            get_model=AsyncMock(return_value=SimpleNamespace(name="My uploaded model"))
+        )
+        roster_patch = (
+            patch.object(model_registry, "MODELS", roster)
+            if roster is not None
+            else nullcontext()
+        )
+        with roster_patch, patch(
+            "astrodash.ui_views.get_model_service", return_value=model_svc
+        ):
+            resp = self.client.get(reverse(url_name))
+        self.assertEqual(resp.status_code, 200)
+        return re.sub(r"<!--.*?-->", "", resp.content.decode(), flags=re.DOTALL)
+
+    def _post_batch(self, model_type, roster=None, **extra):
+        """POST the batch form for a selected model, with an optional roster."""
+        session = self.client.session
+        session["selected_model_type"] = model_type
+        session.save()
+        data = {"smoothing": 0, "min_wave": 3500, "max_wave": 10000}
+        data.update(extra)
+        roster_patch = (
+            patch.object(model_registry, "MODELS", roster)
+            if roster is not None
+            else nullcontext()
+        )
+        with roster_patch:
+            return self.client.post(reverse("astrodash:batch_process_ui"), data=data)
+
+    # --- rendering: neither control for a model that declines redshift ---
+
+    def test_declining_model_renders_no_redshift_controls_in_classify(self):
+        """AE4: no redshift field and no Known Redshift checkbox."""
+        html = self._render_visible(
+            "astrodash:classify",
+            "dash",
+            self._roster(model_registry.REDSHIFT_INPUT_NONE),
+        )
+        self.assertNotIn(self.REDSHIFT_FIELD_MARKER, html)
+        self.assertNotIn(self.KNOWN_Z_FIELD_MARKER, html)
+        # A control proving the form itself still rendered.
+        self.assertIn('id="id_smoothing"', html)
+
+    def test_declining_model_renders_no_redshift_controls_in_batch(self):
+        html = self._render_visible(
+            "astrodash:batch_process_ui",
+            "dash",
+            self._roster(model_registry.REDSHIFT_INPUT_NONE),
+        )
+        self.assertNotIn(self.REDSHIFT_FIELD_MARKER, html)
+        self.assertNotIn(self.KNOWN_Z_FIELD_MARKER, html)
+        self.assertIn('id="id_smoothing"', html)
+
+    def test_optional_policy_still_renders_both_controls_in_classify(self):
+        html = self._render_visible("astrodash:classify", "dash")
+        self.assertIn(self.REDSHIFT_FIELD_MARKER, html)
+        self.assertIn(self.KNOWN_Z_FIELD_MARKER, html)
+
+    def test_optional_policy_still_renders_both_controls_in_batch(self):
+        html = self._render_visible("astrodash:batch_process_ui", "dash")
+        self.assertIn(self.REDSHIFT_FIELD_MARKER, html)
+        self.assertIn(self.KNOWN_Z_FIELD_MARKER, html)
+
+    def test_required_policy_still_renders_both_controls_in_classify(self):
+        html = self._render_visible("astrodash:classify", "transformer")
+        self.assertIn(self.REDSHIFT_FIELD_MARKER, html)
+        self.assertIn(self.KNOWN_Z_FIELD_MARKER, html)
+
+    # --- validation: a submission omitting redshift passes in both flows ---
+
+    def test_declining_model_validates_without_redshift_in_classify(self):
+        with patch.object(
+            model_registry, "MODELS", self._roster(model_registry.REDSHIFT_INPUT_NONE)
+        ):
+            form = ClassifyForm(data=self._base_classify_data("dash"))
+            self.assertTrue(form.is_valid(), form.errors)
+
+    def test_declining_model_validates_without_redshift_in_batch(self):
+        resp = self._post_batch(
+            "dash", roster=self._roster(model_registry.REDSHIFT_INPUT_NONE)
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertNotIn("redshift", resp.context["form"].errors)
+
+    def test_required_policy_rejects_missing_redshift_in_classify(self):
+        """The gate follows the policy, not the model: DASH made required fails."""
+        with patch.object(
+            model_registry,
+            "MODELS",
+            self._roster(model_registry.REDSHIFT_INPUT_REQUIRED),
+        ):
+            form = ClassifyForm(data=self._base_classify_data("dash"))
+            self.assertFalse(form.is_valid())
+            self.assertIn("redshift", form.errors)
+
+    def test_required_policy_rejects_missing_redshift_in_batch(self):
+        resp = self._post_batch(
+            "dash", roster=self._roster(model_registry.REDSHIFT_INPUT_REQUIRED)
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn("redshift", resp.context["form"].errors)
+
+    # --- KTD10: an unresolvable selection keeps today's optional behavior ---
+
+    def test_user_uploaded_selection_still_renders_both_controls(self):
+        html = self._render_visible("astrodash:classify", "user_uploaded")
+        self.assertIn(self.REDSHIFT_FIELD_MARKER, html)
+        self.assertIn(self.KNOWN_Z_FIELD_MARKER, html)
+
+    def test_user_uploaded_selection_still_renders_both_controls_in_batch(self):
+        html = self._render_visible("astrodash:batch_process_ui", "user_uploaded")
+        self.assertIn(self.REDSHIFT_FIELD_MARKER, html)
+        self.assertIn(self.KNOWN_Z_FIELD_MARKER, html)
+
+    def test_user_uploaded_selection_validates_without_redshift(self):
+        form = ClassifyForm(data=self._base_classify_data("user_uploaded"))
+        self.assertTrue(form.is_valid(), form.errors)
+
+    def test_user_uploaded_batch_validates_without_redshift(self):
+        resp = self._post_batch("user_uploaded")
+        self.assertEqual(resp.status_code, 200)
         self.assertNotIn("redshift", resp.context["form"].errors)
 
 

--- a/app/astrodash/tests/test_classifier_parity.py
+++ b/app/astrodash/tests/test_classifier_parity.py
@@ -12,6 +12,7 @@ classification services mocked, so no weights or network access are needed.
 """
 
 import re
+from dataclasses import replace
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -20,7 +21,8 @@ from django.http import HttpResponse
 from django.test import Client, TestCase
 from django.urls import reverse
 
-from astrodash.forms import ClassifyForm
+from astrodash.forms import ClassifyForm, ModelSelectionForm
+from astrodash.infrastructure.ml import model_registry
 from astrodash.ui_views import _format_batch_results
 from astrodash.domain.services.redshift_service import RedshiftService
 from astrodash.domain.services.spectrum_processing_service import (
@@ -91,6 +93,105 @@ class SelectModelPageParityTests(TestCase):
         # The selected-state color is applied inline from data-color; no static
         # CSS rule keyed by data-model-type should remain.
         self.assertNotIn(".model-card.selected[data-model-type", visible)
+
+
+class UnlistedModelSurfaceTests(TestCase):
+    """AE1: an unlisted model leaves every surface an ordinary visitor reaches.
+
+    DASH is made unlisted (but active and ungated) for the duration of each
+    test, following the registry fixture idiom of ``dataclasses.replace`` over
+    a patched roster. Transformer is untouched, so it stays the listed, ungated
+    active default the registry invariants require, and doubles as the control
+    proving only the unlisted model disappeared.
+    """
+
+    def _unlisted_roster(self):
+        """Return a roster where DASH is active and ungated but not listed.
+
+        Returns:
+            tuple: A ``MODELS``-shaped tuple suitable for ``patch.object``.
+        """
+        transformer = model_registry.get_definition("transformer")
+        dash = model_registry.get_definition("dash")
+        return (transformer, replace(dash, listed=False))
+
+    def _render_visible(self, action):
+        """Render the select-model page for an action, comments stripped.
+
+        Args:
+            action: The ``action`` query value, ``"classify"`` or ``"batch"``.
+
+        Returns:
+            str: The rendered HTML with ``<!-- ... -->`` comments removed, so
+            the assertions see only selectable cards (the user-model/upload
+            cards live inside comments).
+        """
+        model_svc = MagicMock(list_models=AsyncMock(return_value=[]))
+        with patch.object(model_registry, "MODELS", self._unlisted_roster()), patch(
+            "astrodash.ui_views.get_model_service", return_value=model_svc
+        ):
+            resp = self.client.get(
+                reverse("astrodash:model_selection") + f"?action={action}"
+            )
+        self.assertEqual(resp.status_code, 200)
+        return re.sub(r"<!--.*?-->", "", resp.content.decode(), flags=re.DOTALL)
+
+    def test_unlisted_model_renders_no_card_for_classify_action(self):
+        visible = self._render_visible("classify")
+        self.assertNotIn("onclick=\"selectModel('dash')\"", visible)
+        self.assertIn("onclick=\"selectModel('transformer')\"", visible)
+
+    def test_unlisted_model_renders_no_card_for_batch_action(self):
+        visible = self._render_visible("batch")
+        self.assertNotIn("onclick=\"selectModel('dash')\"", visible)
+        self.assertIn("onclick=\"selectModel('transformer')\"", visible)
+
+    def test_unlisted_model_absent_from_classify_form_choices(self):
+        with patch.object(model_registry, "MODELS", self._unlisted_roster()):
+            choices = [value for value, _ in ClassifyForm().fields["model"].choices]
+        self.assertNotIn("dash", choices)
+        self.assertIn("transformer", choices)
+        # The user-uploaded entry is unrelated to listing and stays put.
+        self.assertIn("user_uploaded", choices)
+
+    def test_unlisted_model_absent_from_selection_form_choices(self):
+        with patch.object(model_registry, "MODELS", self._unlisted_roster()):
+            choices = [
+                value for value, _ in ModelSelectionForm().fields["model_type"].choices
+            ]
+        self.assertNotIn("dash", choices)
+        self.assertIn("transformer", choices)
+
+    def _post_selection(self, model_type):
+        """POST the selection form naming a model, with the model service mocked.
+
+        Args:
+            model_type: The ``model_type`` value to submit.
+
+        Returns:
+            The view's ``HttpResponse``.
+        """
+        model_svc = MagicMock(list_models=AsyncMock(return_value=[]))
+        with patch.object(model_registry, "MODELS", self._unlisted_roster()), patch(
+            "astrodash.ui_views.get_model_service", return_value=model_svc
+        ):
+            return self.client.post(
+                reverse("astrodash:model_selection"),
+                data={"model_type": model_type, "action_type": "classify"},
+            )
+
+    def test_selection_post_naming_unlisted_model_is_refused(self):
+        resp = self._post_selection("dash")
+        # Refused: the page redisplays instead of redirecting into classify,
+        # and nothing is written to the session.
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn("model_type", resp.context["form"].errors)
+        self.assertIsNone(self.client.session.get("selected_model_type"))
+
+    def test_selection_post_naming_listed_model_still_succeeds(self):
+        resp = self._post_selection("transformer")
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(self.client.session.get("selected_model_type"), "transformer")
 
 
 class ClassifyFormRedshiftParityTests(TestCase):

--- a/app/astrodash/tests/test_model_access.py
+++ b/app/astrodash/tests/test_model_access.py
@@ -21,9 +21,11 @@ import re
 from contextlib import contextmanager
 from dataclasses import replace
 from io import StringIO
-from unittest.mock import patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
+from django.contrib.auth import get_user_model
 from django.core.management import CommandError, call_command
+from django.http import HttpResponse
 from django.test import TestCase
 from django.urls import reverse
 
@@ -106,6 +108,65 @@ def gated_gate(model_id="dash", **config):
 def gate_url(token):
     """Return the entry-link path carrying a token."""
     return reverse("astrodash:model_gate", args=[token])
+
+
+def classify_post(model):
+    """Return a valid classify-form payload naming a model.
+
+    Args:
+        model: The value to put in the form's model field. Inside a scoped
+            flow this is exactly the field an attacker would alter, so tests
+            vary it independently of the scope.
+
+    Returns:
+        dict: The POST data.
+    """
+    return {
+        "supernova_name": "SN2011fe",
+        "model": model,
+        "smoothing": 0,
+        "min_wave": 3500,
+        "max_wave": 10000,
+    }
+
+
+@contextmanager
+def mocked_classification(model_type):
+    """Run the classify view without model weights or network access.
+
+    Args:
+        model_type: The model the mocked classification reports having run.
+
+    Yields:
+        The mocked classification service, so a test can read back which model
+        the view actually asked it to run.
+    """
+    processed = MagicMock()
+    processed.x = [3000.0, 5000.0, 9000.0]
+    processed.y = [1.0, 2.0, 1.0]
+
+    classification = MagicMock()
+    classification.model_type = model_type
+    classification.results = {"best_matches": [], "embedding": [0.0] * 1024}
+
+    classification_svc = MagicMock(
+        classify_spectrum=AsyncMock(return_value=classification)
+    )
+    with patch(
+        "astrodash.ui_views.get_spectrum_service",
+        return_value=MagicMock(get_spectrum_data=AsyncMock(return_value=MagicMock())),
+    ), patch(
+        "astrodash.ui_views.get_spectrum_processing_service",
+        return_value=MagicMock(
+            process_spectrum_with_params=AsyncMock(return_value=processed)
+        ),
+    ), patch(
+        "astrodash.ui_views.get_classification_service",
+        return_value=classification_svc,
+    ), patch(
+        "astrodash.ui_views.render", return_value=HttpResponse(b"")
+    ):
+        yield classification_svc
 
 
 class EntryLinkTokenTests(TestCase):
@@ -348,6 +409,197 @@ class ScopeDeadlineTests(TestCase):
                 self.client.get(reverse("astrodash:classify"))
         self.assertEqual(self.client.session[model_access.SCOPE_DEADLINE_KEY], granted)
         self.assertEqual(granted, 1000.0 + 3600)
+
+
+class ScopeEnforcementTests(TestCase):
+    """R9/R11/R12: every surface that can run a gated model consults the scope."""
+
+    SCOPED_CONTROL_MARKER = 'id="scoped-model-name"'
+
+    def _redeem(self, now=1000.0, ttl_seconds="3600", seed=None):
+        """Establish a scope by redeeming a fresh link.
+
+        Args:
+            now: The POSIX timestamp to mint and redeem at.
+            ttl_seconds: The configured window.
+            seed: Optional session state to seed before redeeming.
+
+        Returns:
+            The absolute deadline the scope was granted with.
+        """
+        if seed:
+            session = self.client.session
+            session.update(seed)
+            session.save()
+        with gated_gate(ttl_seconds=ttl_seconds), patch.object(
+            model_access, "_now", return_value=now
+        ):
+            token = model_access.mint_entry_link("dash")
+            resp = self.client.post(
+                gate_url(token), data={"credential": GATE_CREDENTIAL}
+            )
+        self.assertEqual(resp.status_code, 302)
+        return self.client.session[model_access.SCOPE_DEADLINE_KEY]
+
+    def _seed_selection(self, **extra):
+        session = self.client.session
+        session["selected_model_type"] = "dash"
+        session.update(extra)
+        session.save()
+
+    # --- refused without a scope ---
+
+    def test_gated_classification_view_is_refused_without_a_scope(self):
+        self._seed_selection()
+        with gated_gate(), patch.object(model_access, "_now", return_value=1000.0):
+            resp = self.client.get(reverse("astrodash:classify"))
+        self.assertEqual(resp.status_code, 302)
+        self.assertTrue(
+            resp["Location"].startswith(reverse("astrodash:model_selection")),
+            resp["Location"],
+        )
+
+    def test_gated_surface_page_route_is_refused_without_a_scope(self):
+        self._seed_selection()
+        with gated_gate(), patch.object(model_access, "_now", return_value=1000.0):
+            resp = self.client.get(reverse("astrodash:dash_twins"))
+        self.assertEqual(resp.status_code, 403)
+
+    def test_gated_surface_data_route_is_refused_without_a_scope(self):
+        self._seed_selection()
+        with gated_gate(), patch.object(model_access, "_now", return_value=1000.0):
+            resp = self.client.get(reverse("astrodash:dash_twins_data"))
+        self.assertEqual(resp.status_code, 403)
+
+    def test_gated_surface_search_route_is_refused_without_a_scope(self):
+        self._seed_selection(
+            classify_model_type="dash", classify_dash_embedding=[0.0] * 1024
+        )
+        with gated_gate(), patch.object(model_access, "_now", return_value=1000.0):
+            resp = self.client.get(reverse("astrodash:twins_search"))
+        self.assertEqual(resp.status_code, 403)
+
+    # --- the model control in a scoped session ---
+
+    def test_scoped_session_renders_the_model_control_disabled_and_named(self):
+        self._redeem()
+        with gated_gate(), patch.object(model_access, "_now", return_value=1001.0):
+            resp = self.client.get(reverse("astrodash:classify"))
+        body = resp.content.decode()
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn(self.SCOPED_CONTROL_MARKER, body)
+        control = re.search(r"<input[^>]*id=\"scoped-model-name\"[^>]*>", body).group(0)
+        self.assertIn("disabled", control)
+        self.assertIn(model_registry.get_definition("dash").title, control)
+        # The dropdown is not offered alongside it.
+        self.assertNotIn('id="id_model"', body)
+
+    # --- the model that actually runs ---
+
+    def test_scoped_submission_validates_though_the_model_is_unlisted(self):
+        """A gated model is unlisted, so its id is in no listed choice set."""
+        self._redeem()
+        with gated_gate(), patch.object(
+            model_access, "_now", return_value=1001.0
+        ), mocked_classification("dash") as classification_svc:
+            self.client.post(reverse("astrodash:classify"), data=classify_post("dash"))
+        self.assertEqual(
+            classification_svc.classify_spectrum.await_args.kwargs["model_type"], "dash"
+        )
+
+    def test_altered_request_still_runs_the_scoped_model(self):
+        """AE3: the request cannot be moved to another model."""
+        self._redeem()
+        with gated_gate(), patch.object(
+            model_access, "_now", return_value=1001.0
+        ), mocked_classification("dash") as classification_svc:
+            self.client.post(
+                reverse("astrodash:classify"), data=classify_post("transformer")
+            )
+        self.assertEqual(
+            classification_svc.classify_spectrum.await_args.kwargs["model_type"], "dash"
+        )
+
+    def test_prior_uploaded_selection_does_not_survive_into_the_scope(self):
+        """AE15: a stale selection cannot displace the scope."""
+        self._redeem(
+            seed={"selected_model_type": "user_uploaded", "selected_model_id": "um-1"}
+        )
+        with gated_gate(), patch.object(
+            model_access, "_now", return_value=1001.0
+        ), mocked_classification("dash") as classification_svc:
+            self.client.post(reverse("astrodash:classify"), data=classify_post("dash"))
+        kwargs = classification_svc.classify_spectrum.await_args.kwargs
+        self.assertEqual(kwargs["model_type"], "dash")
+        self.assertIsNone(kwargs["user_model_id"])
+
+    # --- the deadline is a lifetime, not an idle timeout ---
+
+    def test_continuous_classification_still_loses_access_at_the_deadline(self):
+        """AE10: activity must not extend the deadline."""
+        deadline = self._redeem(now=1000.0, ttl_seconds="3600")
+        for tick in (1001.0, 2000.0, 3000.0, 4000.0):
+            with gated_gate(), patch.object(
+                model_access, "_now", return_value=tick
+            ), mocked_classification("dash"):
+                resp = self.client.post(
+                    reverse("astrodash:classify"), data=classify_post("dash")
+                )
+            self.assertEqual(resp.status_code, 200, f"refused early at {tick}")
+            self.assertEqual(
+                self.client.session[model_access.SCOPE_DEADLINE_KEY], deadline
+            )
+        with gated_gate(), patch.object(
+            model_access, "_now", return_value=deadline + 1
+        ):
+            resp = self.client.get(reverse("astrodash:classify"))
+        self.assertEqual(resp.status_code, 403)
+        self.assertIn(CredentialPromptTests.REFUSAL_MARKER, resp.content.decode())
+        self.assertNotIn(model_access.SCOPE_MODEL_KEY, self.client.session)
+
+    def test_lapsed_scope_refusal_names_no_model(self):
+        deadline = self._redeem()
+        with gated_gate(), patch.object(
+            model_access, "_now", return_value=deadline + 1
+        ):
+            resp = self.client.get(reverse("astrodash:classify"))
+        body = resp.content.decode()
+        self.assertNotIn("dash", body.lower().replace("astrodash", ""))
+
+    def test_scope_survives_django_login_with_its_deadline_intact(self):
+        deadline = self._redeem()
+        user = get_user_model().objects.create_user(
+            username="reviewer", password="not-the-gate-credential"
+        )
+        self.client.force_login(user)
+        session = self.client.session
+        self.assertEqual(session[model_access.SCOPE_MODEL_KEY], "dash")
+        self.assertEqual(session[model_access.SCOPE_DEADLINE_KEY], deadline)
+        with gated_gate(), patch.object(model_access, "_now", return_value=1001.0):
+            resp = self.client.get(reverse("astrodash:classify"))
+        self.assertEqual(resp.status_code, 200)
+
+
+class UngatedFlowUnaffectedTests(TestCase):
+    """R21: with no gated model anywhere, nothing about the gate is visible."""
+
+    def test_public_classify_page_still_renders_the_model_dropdown(self):
+        session = self.client.session
+        session["selected_model_type"] = "dash"
+        session.save()
+        resp = self.client.get(reverse("astrodash:classify"))
+        body = resp.content.decode()
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn('id="id_model"', body)
+        self.assertNotIn(ScopeEnforcementTests.SCOPED_CONTROL_MARKER, body)
+
+    def test_public_twins_routes_still_served_for_dash(self):
+        session = self.client.session
+        session["selected_model_type"] = "dash"
+        session.save()
+        self.assertEqual(
+            self.client.get(reverse("astrodash:dash_twins")).status_code, 200
+        )
 
 
 class MintCommandTests(TestCase):

--- a/app/astrodash/tests/test_model_access.py
+++ b/app/astrodash/tests/test_model_access.py
@@ -18,7 +18,6 @@ client hits the sessions table.
 
 import os
 import re
-from contextlib import contextmanager
 from dataclasses import replace
 from io import StringIO
 from types import SimpleNamespace
@@ -26,148 +25,21 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from django.contrib.auth import get_user_model
 from django.core.management import CommandError, call_command
-from django.http import HttpResponse
 from django.test import TestCase
 from django.urls import reverse
 
 from astrodash.core import gate_config, model_access
 from astrodash.infrastructure.ml import model_registry
-
-# The shared credential and signing key every test configures. Neither may be
-# blank or carry the committed ``django-insecure-`` prefix, or the gate reads
-# them as unconfigured.
-GATE_CREDENTIAL = "review-window-access-code"
-GATE_SIGNING_KEY = "test-entry-link-signing-key"
-GATE_LINK_BASE_URL = "https://astrodash-dev.example.org"
-
-
-def gated_roster(model_id="dash"):
-    """Return a roster in which one built-in model is gated.
-
-    Args:
-        model_id: The built-in id to gate. It is made unlisted at the same
-            time, because the registry forbids a gated model from being listed.
-
-    Returns:
-        tuple: A ``MODELS``-shaped tuple suitable for ``patch.object``.
-    """
-    return tuple(
-        replace(m, listed=False, requires_credential=True) if m.id == model_id else m
-        for m in model_registry.MODELS
-    )
-
-
-@contextmanager
-def gate_configured(
-    credential=GATE_CREDENTIAL, ttl_seconds="3600", signing_key=GATE_SIGNING_KEY
-):
-    """Configure the gate's deployment values for the duration of the block.
-
-    The normalized configuration is patched in rather than driven through the
-    environment, because the entry-link signing key *is* ``SECRET_KEY``: moving
-    the real setting would re-sign the test client's session cookie mid-test and
-    every session assertion here would read an empty session instead of the one
-    the gate wrote. ``gate_config``'s own normalization is covered by the
-    registry tests. The link host is a separate value that no session depends
-    on, so it stays an environment read.
-
-    Args:
-        credential: The shared credential an operator would configure.
-        ttl_seconds: The entry-link expiry window, as an operator sets it.
-        signing_key: The key entry links are signed with.
-
-    Yields:
-        None.
-    """
-    configuration = {
-        gate_config.CREDENTIAL_ENV_VAR: credential,
-        gate_config.LINK_TTL_ENV_VAR: ttl_seconds,
-        gate_config.SIGNING_KEY_NAME: signing_key,
-    }
-    with patch.object(
-        model_access, "gate_configuration", return_value=configuration
-    ), patch.dict(os.environ, {gate_config.LINK_BASE_URL_ENV_VAR: GATE_LINK_BASE_URL}):
-        yield
-
-
-@contextmanager
-def gated_gate(model_id="dash", **config):
-    """Patch in a gated roster *and* the gate configuration together.
-
-    Args:
-        model_id: The built-in id to gate.
-        **config: Passed through to :func:`gate_configured`.
-
-    Yields:
-        None.
-    """
-    with patch.object(model_registry, "MODELS", gated_roster(model_id)):
-        with gate_configured(**config):
-            yield
-
-
-def gate_url(token):
-    """Return the entry-link path carrying a token."""
-    return reverse("astrodash:model_gate", args=[token])
-
-
-def classify_post(model):
-    """Return a valid classify-form payload naming a model.
-
-    Args:
-        model: The value to put in the form's model field. Inside a scoped
-            flow this is exactly the field an attacker would alter, so tests
-            vary it independently of the scope.
-
-    Returns:
-        dict: The POST data.
-    """
-    return {
-        "supernova_name": "SN2011fe",
-        "model": model,
-        "smoothing": 0,
-        "min_wave": 3500,
-        "max_wave": 10000,
-    }
-
-
-@contextmanager
-def mocked_classification(model_type):
-    """Run the classify view without model weights or network access.
-
-    Args:
-        model_type: The model the mocked classification reports having run.
-
-    Yields:
-        The mocked classification service, so a test can read back which model
-        the view actually asked it to run.
-    """
-    processed = MagicMock()
-    processed.x = [3000.0, 5000.0, 9000.0]
-    processed.y = [1.0, 2.0, 1.0]
-
-    classification = MagicMock()
-    classification.model_type = model_type
-    classification.results = {"best_matches": [], "embedding": [0.0] * 1024}
-
-    classification_svc = MagicMock(
-        classify_spectrum=AsyncMock(return_value=classification)
-    )
-    with patch(
-        "astrodash.ui_views.get_spectrum_service",
-        return_value=MagicMock(get_spectrum_data=AsyncMock(return_value=MagicMock())),
-    ), patch(
-        "astrodash.ui_views.get_spectrum_processing_service",
-        return_value=MagicMock(
-            process_spectrum_with_params=AsyncMock(return_value=processed)
-        ),
-    ), patch(
-        "astrodash.ui_views.get_classification_service",
-        return_value=classification_svc,
-    ), patch(
-        "astrodash.ui_views.render", return_value=HttpResponse(b"")
-    ):
-        yield classification_svc
+from astrodash.tests.gate_fixtures import (
+    GATE_CREDENTIAL,
+    GATE_LINK_BASE_URL,
+    classify_post,
+    gate_configured,
+    gate_url,
+    gated_gate,
+    gated_roster,
+    mocked_classification,
+)
 
 
 class EntryLinkTokenTests(TestCase):
@@ -810,6 +682,28 @@ class UngatedFlowUnaffectedTests(TestCase):
         self.assertEqual(resp.status_code, 200)
         self.assertIn('id="id_model"', body)
         self.assertNotIn(ScopeEnforcementTests.SCOPED_CONTROL_MARKER, body)
+
+    def test_user_uploaded_model_still_classifies_unchanged(self):
+        """R23/AE7: the gate work leaves the uploaded-model path alone."""
+        session = self.client.session
+        session["selected_model_type"] = "user_uploaded"
+        session["selected_model_id"] = "um-1"
+        session.save()
+        model_svc = MagicMock(
+            get_model=AsyncMock(return_value=SimpleNamespace(name="My model"))
+        )
+        with patch(
+            "astrodash.ui_views.get_model_service", return_value=model_svc
+        ), mocked_classification("user_uploaded") as classification_svc:
+            self.client.post(
+                reverse("astrodash:classify"), data=classify_post("user_uploaded")
+            )
+        kwargs = classification_svc.classify_spectrum.await_args.kwargs
+        self.assertEqual(kwargs["model_type"], "user_uploaded")
+        self.assertEqual(kwargs["user_model_id"], "um-1")
+        # A model the registry cannot resolve declares no twins surface, so
+        # nothing is stashed for it -- exactly as before.
+        self.assertNotIn("classify_dash_embedding", self.client.session)
 
     def test_public_twins_routes_still_served_for_dash(self):
         session = self.client.session

--- a/app/astrodash/tests/test_model_access.py
+++ b/app/astrodash/tests/test_model_access.py
@@ -464,6 +464,20 @@ class ScopeEnforcementTests(TestCase):
         # The dropdown is not offered alongside it.
         self.assertNotIn('id="id_model"', body)
 
+    def test_scoped_page_leaks_no_template_comment_text(self):
+        """A ``{# #}`` comment that spans lines is rendered, not stripped."""
+        self._redeem()
+        with gated_gate(), patch.object(model_access, "_now", return_value=1001.0):
+            resp = self.client.get(reverse("astrodash:classify"))
+        body = resp.content.decode()
+        self.assertEqual(resp.status_code, 200)
+        for delimiter in ("{#", "#}"):
+            self.assertNotIn(
+                delimiter,
+                body,
+                "template comment delimiters reached the rendered page",
+            )
+
     # --- the model that actually runs ---
 
     def test_scoped_submission_validates_though_the_model_is_unlisted(self):

--- a/app/astrodash/tests/test_model_access.py
+++ b/app/astrodash/tests/test_model_access.py
@@ -39,6 +39,7 @@ from astrodash.tests.gate_fixtures import (
     gated_gate,
     gated_roster,
     mocked_classification,
+    redeem_scope,
 )
 
 
@@ -113,6 +114,110 @@ class EntryLinkTokenTests(TestCase):
         with patch.dict(os.environ, env):
             with self.assertRaises(model_access.GateNotConfigured):
                 model_access.mint_entry_link("dash")
+
+
+class UnconfiguredGateTests(TestCase):
+    """R34: the entry-link route exists everywhere, configured or not.
+
+    The route is registered in every deployment, but the startup check only
+    runs when the roster carries a gated model -- so in the shipped default the
+    gate is unconfigured and a visitor can still reach the route. It must fail
+    closed onto the refusal page rather than a framework error page.
+    """
+
+    REFUSAL_MARKER = 'id="model-gate-refused"'
+
+    def _unconfigured(self):
+        return patch.object(
+            model_access,
+            "gate_configuration",
+            return_value={
+                gate_config.CREDENTIAL_ENV_VAR: None,
+                gate_config.LINK_TTL_ENV_VAR: None,
+                gate_config.SIGNING_KEY_NAME: None,
+            },
+        )
+
+    def test_link_presented_to_an_unconfigured_gate_is_refused(self):
+        with self._unconfigured():
+            resp = self.client.get(gate_url("any-token-at-all"))
+        self.assertEqual(resp.status_code, 403)
+        self.assertIn(self.REFUSAL_MARKER, resp.content.decode())
+
+    def test_credential_submitted_to_an_unconfigured_gate_is_refused(self):
+        # Mint while configured, then present the link to a deployment that is
+        # not: the token resolves only if the signing key is still readable.
+        with gated_gate(), patch.object(model_access, "_now", return_value=1000.0):
+            token = model_access.mint_entry_link("dash")
+        with patch.object(model_registry, "MODELS", gated_roster()), patch.object(
+            model_access,
+            "gate_configuration",
+            return_value={
+                gate_config.CREDENTIAL_ENV_VAR: None,
+                gate_config.LINK_TTL_ENV_VAR: "3600",
+                gate_config.SIGNING_KEY_NAME: "test-entry-link-signing-key",
+            },
+        ), patch.object(model_access, "_now", return_value=1001.0):
+            resp = self.client.post(gate_url(token), data={"credential": "anything"})
+        self.assertEqual(resp.status_code, 403)
+        self.assertIn(self.REFUSAL_MARKER, resp.content.decode())
+        self.assertNotIn(model_access.SCOPE_MODEL_KEY, self.client.session)
+
+
+class SessionIdentityTests(TestCase):
+    """Authorization is never written into a session id that predates it."""
+
+    def test_granting_a_scope_rotates_the_session_key(self):
+        # Give the client a session before it earns anything.
+        session = self.client.session
+        session["selected_model_type"] = "transformer"
+        session.save()
+        before = self.client.cookies["sessionid"].value
+
+        redeem_scope(self.client, self)
+
+        after = self.client.cookies["sessionid"].value
+        self.assertNotEqual(before, after)
+        self.assertEqual(self.client.session[model_access.SCOPE_MODEL_KEY], "dash")
+
+    def test_rotation_keeps_an_authenticated_visitor_logged_in(self):
+        user = get_user_model().objects.create_user(
+            username="reviewer-4", password="not-the-gate-credential"
+        )
+        self.client.force_login(user)
+        redeem_scope(self.client, self)
+        self.assertEqual(self.client.session.get("_auth_user_id"), str(user.pk))
+
+
+class ScopeExpiryEdgeTests(TestCase):
+    """The deadline check fails closed on a scope it cannot evaluate."""
+
+    def _session_with(self, deadline):
+        session = self.client.session
+        session[model_access.SCOPE_MODEL_KEY] = "dash"
+        if deadline is not None:
+            session[model_access.SCOPE_DEADLINE_KEY] = deadline
+        session.save()
+        return self.client.session
+
+    def test_scope_without_a_stored_deadline_is_expired(self):
+        with patch.object(model_access, "_now", return_value=1000.0):
+            self.assertTrue(model_access.scope_expired(self._session_with(None)))
+
+    def test_scope_with_an_unreadable_deadline_is_expired(self):
+        with patch.object(model_access, "_now", return_value=1000.0):
+            self.assertTrue(model_access.scope_expired(self._session_with("soon")))
+
+    def test_an_unevaluable_scope_refuses_the_classification_view(self):
+        self._session_with("soon")
+        with gated_gate(), patch.object(model_access, "_now", return_value=1000.0):
+            resp = self.client.get(reverse("astrodash:classify"))
+        self.assertEqual(resp.status_code, 403)
+        self.assertNotIn(model_access.SCOPE_MODEL_KEY, self.client.session)
+
+    def test_a_live_scope_is_not_expired(self):
+        with patch.object(model_access, "_now", return_value=1000.0):
+            self.assertFalse(model_access.scope_expired(self._session_with(2000.0)))
 
 
 class CredentialPromptTests(TestCase):
@@ -290,7 +395,7 @@ class ScopeEnforcementTests(TestCase):
     SCOPED_CONTROL_MARKER = 'id="scoped-model-name"'
 
     def _redeem(self, now=1000.0, ttl_seconds="3600", seed=None):
-        """Establish a scope by redeeming a fresh link.
+        """Establish a scope, optionally over seeded session state.
 
         Args:
             now: The POSIX timestamp to mint and redeem at.
@@ -304,15 +409,7 @@ class ScopeEnforcementTests(TestCase):
             session = self.client.session
             session.update(seed)
             session.save()
-        with gated_gate(ttl_seconds=ttl_seconds), patch.object(
-            model_access, "_now", return_value=now
-        ):
-            token = model_access.mint_entry_link("dash")
-            resp = self.client.post(
-                gate_url(token), data={"credential": GATE_CREDENTIAL}
-            )
-        self.assertEqual(resp.status_code, 302)
-        return self.client.session[model_access.SCOPE_DEADLINE_KEY]
+        return redeem_scope(self.client, self, now=now, ttl_seconds=ttl_seconds)
 
     def _seed_selection(self, **extra):
         session = self.client.session
@@ -459,15 +556,7 @@ class ScopeBoundaryTests(TestCase):
     END_CONTROL_MARKER = 'id="end-scope-button"'
 
     def _redeem(self, now=1000.0, ttl_seconds="3600"):
-        with gated_gate(ttl_seconds=ttl_seconds), patch.object(
-            model_access, "_now", return_value=now
-        ):
-            token = model_access.mint_entry_link("dash")
-            resp = self.client.post(
-                gate_url(token), data={"credential": GATE_CREDENTIAL}
-            )
-        self.assertEqual(resp.status_code, 302)
-        return self.client.session[model_access.SCOPE_DEADLINE_KEY]
+        return redeem_scope(self.client, self, now=now, ttl_seconds=ttl_seconds)
 
     # --- a scope reaches classification only ---
 
@@ -626,6 +715,52 @@ class ScopeBoundaryTests(TestCase):
             resp["Location"],
         )
 
+    def test_scope_whose_model_was_retired_is_released(self):
+        """R35: retirement makes a model unselectable, scope or no scope."""
+        self._redeem()
+        retired = tuple(
+            replace(m, status=model_registry.STATUS_RETIRED) if m.id == "dash" else m
+            for m in gated_roster()
+        )
+        with patch.object(
+            model_registry, "MODELS", retired
+        ), gate_configured(), patch.object(model_access, "_now", return_value=1001.0):
+            resp = self.client.get(reverse("astrodash:classify"))
+        self.assertEqual(resp.status_code, 302)
+        self.assertTrue(
+            resp["Location"].startswith(reverse("astrodash:model_selection")),
+            resp["Location"],
+        )
+        self.assertNotIn(model_access.SCOPE_MODEL_KEY, self.client.session)
+
+    def test_mint_command_refuses_a_retired_gated_model(self):
+        retired = tuple(
+            replace(m, status=model_registry.STATUS_RETIRED) if m.id == "dash" else m
+            for m in gated_roster()
+        )
+        with patch.object(model_registry, "MODELS", retired), gate_configured():
+            with self.assertRaises(CommandError):
+                call_command("mint_model_link", "dash", stdout=StringIO())
+
+    def test_scoped_session_reaches_twins_search_after_classifying(self):
+        """The scoped happy path, not only its refusals."""
+        self._redeem()
+        with gated_gate(), patch.object(
+            model_access, "_now", return_value=1001.0
+        ), mocked_classification("dash"):
+            self.client.post(reverse("astrodash:classify"), data=classify_post("dash"))
+        twins_svc = MagicMock(
+            find_twins=MagicMock(
+                return_value={"twin_indices": [1], "twin_similarities": [0.9]}
+            )
+        )
+        with gated_gate(), patch.object(
+            model_access, "_now", return_value=1002.0
+        ), patch("astrodash.ui_views.get_twins_search_service", return_value=twins_svc):
+            resp = self.client.get(reverse("astrodash:twins_search"))
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()["twin_indices"], [1])
+
     def test_scope_whose_model_was_published_dissolves_on_the_next_request(self):
         self._redeem()
         # No gated roster: the model has been published since the scope began.
@@ -764,6 +899,29 @@ class MintCommandTests(TestCase):
             os.environ.pop(gate_config.LINK_BASE_URL_ENV_VAR, None)
             with self.assertRaises(CommandError):
                 call_command("mint_model_link", "dash", stdout=StringIO())
+
+
+class LinkBaseUrlTests(TestCase):
+    """The mint command's host is normalized, since it is pasted into a link."""
+
+    def _base_url(self, value):
+        with patch.dict(os.environ, {gate_config.LINK_BASE_URL_ENV_VAR: value}):
+            return gate_config.link_base_url()
+
+    def test_trailing_slash_is_stripped(self):
+        self.assertEqual(
+            self._base_url("https://astrodash-dev.example.org/"),
+            "https://astrodash-dev.example.org",
+        )
+
+    def test_surrounding_whitespace_is_stripped(self):
+        self.assertEqual(
+            self._base_url("  https://astrodash-dev.example.org  "),
+            "https://astrodash-dev.example.org",
+        )
+
+    def test_a_blank_value_is_unconfigured(self):
+        self.assertIsNone(self._base_url("   "))
 
 
 class SessionCookieSecurityTests(TestCase):

--- a/app/astrodash/tests/test_model_access.py
+++ b/app/astrodash/tests/test_model_access.py
@@ -1,0 +1,427 @@
+"""The gated-model access gate: entry links, the credential prompt, the scope.
+
+A gated model (one whose definition declares ``requires_credential``) is
+reachable only by redeeming a model-scoped entry link and presenting the shared
+credential, which establishes a session scoped to that one model.
+
+Every test here builds its gated model with ``dataclasses.replace`` over a real
+definition plus a patched roster (KTD9): DASH becomes gated -- and therefore
+unlisted, which the registry invariants require -- while Transformer is left
+untouched so it keeps satisfying the listed, ungated active-default invariant.
+Such a fixture never passes through the import-time validators, so nothing here
+reloads modules.
+
+These need a database: no session engine is configured, so sessions are
+database-backed and anything driving the prompt or the scope through the test
+client hits the sessions table.
+"""
+
+import os
+import re
+from contextlib import contextmanager
+from dataclasses import replace
+from io import StringIO
+from unittest.mock import patch
+
+from django.core.management import CommandError, call_command
+from django.test import TestCase
+from django.urls import reverse
+
+from astrodash.core import gate_config, model_access
+from astrodash.infrastructure.ml import model_registry
+
+# The shared credential and signing key every test configures. Neither may be
+# blank or carry the committed ``django-insecure-`` prefix, or the gate reads
+# them as unconfigured.
+GATE_CREDENTIAL = "review-window-access-code"
+GATE_SIGNING_KEY = "test-entry-link-signing-key"
+GATE_LINK_BASE_URL = "https://astrodash-dev.example.org"
+
+
+def gated_roster(model_id="dash"):
+    """Return a roster in which one built-in model is gated.
+
+    Args:
+        model_id: The built-in id to gate. It is made unlisted at the same
+            time, because the registry forbids a gated model from being listed.
+
+    Returns:
+        tuple: A ``MODELS``-shaped tuple suitable for ``patch.object``.
+    """
+    return tuple(
+        replace(m, listed=False, requires_credential=True) if m.id == model_id else m
+        for m in model_registry.MODELS
+    )
+
+
+@contextmanager
+def gate_configured(
+    credential=GATE_CREDENTIAL, ttl_seconds="3600", signing_key=GATE_SIGNING_KEY
+):
+    """Configure the gate's deployment values for the duration of the block.
+
+    The normalized configuration is patched in rather than driven through the
+    environment, because the entry-link signing key *is* ``SECRET_KEY``: moving
+    the real setting would re-sign the test client's session cookie mid-test and
+    every session assertion here would read an empty session instead of the one
+    the gate wrote. ``gate_config``'s own normalization is covered by the
+    registry tests. The link host is a separate value that no session depends
+    on, so it stays an environment read.
+
+    Args:
+        credential: The shared credential an operator would configure.
+        ttl_seconds: The entry-link expiry window, as an operator sets it.
+        signing_key: The key entry links are signed with.
+
+    Yields:
+        None.
+    """
+    configuration = {
+        gate_config.CREDENTIAL_ENV_VAR: credential,
+        gate_config.LINK_TTL_ENV_VAR: ttl_seconds,
+        gate_config.SIGNING_KEY_NAME: signing_key,
+    }
+    with patch.object(
+        model_access, "gate_configuration", return_value=configuration
+    ), patch.dict(os.environ, {gate_config.LINK_BASE_URL_ENV_VAR: GATE_LINK_BASE_URL}):
+        yield
+
+
+@contextmanager
+def gated_gate(model_id="dash", **config):
+    """Patch in a gated roster *and* the gate configuration together.
+
+    Args:
+        model_id: The built-in id to gate.
+        **config: Passed through to :func:`gate_configured`.
+
+    Yields:
+        None.
+    """
+    with patch.object(model_registry, "MODELS", gated_roster(model_id)):
+        with gate_configured(**config):
+            yield
+
+
+def gate_url(token):
+    """Return the entry-link path carrying a token."""
+    return reverse("astrodash:model_gate", args=[token])
+
+
+class EntryLinkTokenTests(TestCase):
+    """R6/R8/R28: what a minted token carries and when it stops resolving."""
+
+    def test_minted_link_resolves_to_its_model(self):
+        with gated_gate():
+            token = model_access.mint_entry_link("dash")
+            link = model_access.redeem_entry_link(token)
+        self.assertEqual(link.model_id, "dash")
+
+    def test_deadline_is_stamped_at_mint_not_evaluated_later(self):
+        """KTD2: shortening the window cannot move an outstanding link's deadline."""
+        with gated_gate(ttl_seconds="3600"), patch.object(
+            model_access, "_now", return_value=1000.0
+        ):
+            token = model_access.mint_entry_link("dash")
+        # The window is shortened after the link was minted; the link keeps the
+        # deadline it was stamped with.
+        with gated_gate(ttl_seconds="60"), patch.object(
+            model_access, "_now", return_value=1000.0
+        ):
+            link = model_access.redeem_entry_link(token)
+        self.assertEqual(link.expires_at, 1000.0 + 3600)
+
+    def test_expired_link_is_refused(self):
+        with gated_gate(ttl_seconds="60"), patch.object(
+            model_access, "_now", return_value=1000.0
+        ):
+            token = model_access.mint_entry_link("dash")
+        with gated_gate(), patch.object(model_access, "_now", return_value=5000.0):
+            with self.assertRaises(model_access.EntryLinkRefused):
+                model_access.redeem_entry_link(token)
+
+    def test_tampered_token_is_refused(self):
+        with gated_gate():
+            token = model_access.mint_entry_link("dash")
+            with self.assertRaises(model_access.EntryLinkRefused):
+                model_access.redeem_entry_link(token[:-2] + "xy")
+
+    def test_link_signed_with_another_key_is_refused(self):
+        with gated_gate():
+            token = model_access.mint_entry_link("dash")
+        with gated_gate(signing_key="a-different-signing-key"):
+            with self.assertRaises(model_access.EntryLinkRefused):
+                model_access.redeem_entry_link(token)
+
+    def test_minting_without_configuration_fails_closed(self):
+        unconfigured = {
+            gate_config.CREDENTIAL_ENV_VAR: None,
+            gate_config.LINK_TTL_ENV_VAR: None,
+            gate_config.SIGNING_KEY_NAME: None,
+        }
+        with patch.object(
+            model_access, "gate_configuration", return_value=unconfigured
+        ):
+            with self.assertRaises(model_access.GateNotConfigured):
+                model_access.mint_entry_link("dash")
+
+    def test_committed_signing_key_refuses_to_mint(self):
+        """R34: a key published in the repository signs nothing.
+
+        Read through the real configuration path, so the committed
+        ``django-insecure-`` default this deployment still carries is what makes
+        it fail.
+        """
+        env = {
+            gate_config.CREDENTIAL_ENV_VAR: GATE_CREDENTIAL,
+            gate_config.LINK_TTL_ENV_VAR: "3600",
+        }
+        with patch.dict(os.environ, env):
+            with self.assertRaises(model_access.GateNotConfigured):
+                model_access.mint_entry_link("dash")
+
+
+class CredentialPromptTests(TestCase):
+    """R7/R8/AE2/AE11: what an entry link shows, and what a refusal discloses."""
+
+    # A marker the refusal template carries, proving the response is our page
+    # and not a framework default error page.
+    REFUSAL_MARKER = 'id="model-gate-refused"'
+    PROMPT_MARKER = 'id="model-gate-credential"'
+
+    def _mint(self, ttl_seconds="3600", now=1000.0):
+        with gated_gate(ttl_seconds=ttl_seconds), patch.object(
+            model_access, "_now", return_value=now
+        ):
+            return model_access.mint_entry_link("dash")
+
+    def test_unexpired_link_renders_the_credential_prompt(self):
+        token = self._mint()
+        with gated_gate(), patch.object(model_access, "_now", return_value=1001.0):
+            resp = self.client.get(gate_url(token))
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn(self.PROMPT_MARKER, resp.content.decode())
+
+    def test_expired_link_renders_the_refusal_and_names_no_model(self):
+        """AE2: refused, and the response reveals nothing about the model."""
+        token = self._mint(ttl_seconds="60")
+        with gated_gate(), patch.object(model_access, "_now", return_value=9000.0):
+            resp = self.client.get(gate_url(token))
+        body = resp.content.decode()
+        self.assertEqual(resp.status_code, 403)
+        self.assertIn(self.REFUSAL_MARKER, body)
+        self.assertNotIn(self.PROMPT_MARKER, body)
+        self.assertNotIn("dash", body.lower().replace("astrodash", ""))
+
+    def test_tampered_token_is_indistinguishable_from_the_expired_case(self):
+        token = self._mint()
+        with gated_gate(), patch.object(model_access, "_now", return_value=1001.0):
+            tampered = self.client.get(gate_url(token[:-2] + "xy"))
+        expired_token = self._mint(ttl_seconds="60")
+        with gated_gate(), patch.object(model_access, "_now", return_value=9000.0):
+            expired = self.client.get(gate_url(expired_token))
+        self.assertEqual(tampered.status_code, expired.status_code)
+        self.assertEqual(tampered.content, expired.content)
+
+    def test_correct_credential_scopes_the_session_to_that_model(self):
+        token = self._mint()
+        with gated_gate(), patch.object(model_access, "_now", return_value=1001.0):
+            resp = self.client.post(
+                gate_url(token), data={"credential": GATE_CREDENTIAL}
+            )
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(resp["Location"], reverse("astrodash:classify"))
+        session = self.client.session
+        self.assertEqual(session[model_access.SCOPE_MODEL_KEY], "dash")
+        self.assertEqual(session[model_access.SCOPE_DEADLINE_KEY], 1000.0 + 3600)
+
+    def test_incorrect_credential_redisplays_the_prompt_and_permits_retry(self):
+        """AE11: a mistyped credential on a valid link is retryable."""
+        token = self._mint()
+        with gated_gate(), patch.object(model_access, "_now", return_value=1001.0):
+            wrong = self.client.post(gate_url(token), data={"credential": "not-it"})
+            body = wrong.content.decode()
+            self.assertEqual(wrong.status_code, 200)
+            self.assertIn(self.PROMPT_MARKER, body)
+            self.assertNotIn(self.REFUSAL_MARKER, body)
+            self.assertNotIn(model_access.SCOPE_MODEL_KEY, self.client.session)
+            # The same link still works on the next attempt.
+            ok = self.client.post(gate_url(token), data={"credential": GATE_CREDENTIAL})
+        self.assertEqual(ok.status_code, 302)
+        self.assertEqual(self.client.session[model_access.SCOPE_MODEL_KEY], "dash")
+
+    def test_wrong_credential_error_names_no_model(self):
+        token = self._mint()
+        with gated_gate(), patch.object(model_access, "_now", return_value=1001.0):
+            resp = self.client.post(gate_url(token), data={"credential": "not-it"})
+        body = resp.content.decode()
+        self.assertNotIn("dash", body.lower().replace("astrodash", ""))
+
+    def test_link_lapsing_between_prompt_and_submit_is_refused(self):
+        token = self._mint(ttl_seconds="60")
+        with gated_gate(ttl_seconds="60"), patch.object(
+            model_access, "_now", return_value=1001.0
+        ):
+            prompt = self.client.get(gate_url(token))
+        self.assertEqual(prompt.status_code, 200)
+        with gated_gate(ttl_seconds="60"), patch.object(
+            model_access, "_now", return_value=9000.0
+        ):
+            resp = self.client.post(
+                gate_url(token), data={"credential": GATE_CREDENTIAL}
+            )
+        self.assertEqual(resp.status_code, 403)
+        self.assertIn(self.REFUSAL_MARKER, resp.content.decode())
+        self.assertNotIn(model_access.SCOPE_MODEL_KEY, self.client.session)
+
+    def test_published_model_link_redirects_into_the_public_flow(self):
+        """A reviewer is never locked out of a model that has become public."""
+        token = self._mint()
+        # No gated roster this time: the model has been published, so its
+        # definition no longer requires a credential.
+        with gate_configured(), patch.object(model_access, "_now", return_value=1001.0):
+            resp = self.client.get(gate_url(token))
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(resp["Location"], reverse("astrodash:classify"))
+        session = self.client.session
+        self.assertEqual(session["selected_model_type"], "dash")
+        self.assertNotIn(model_access.SCOPE_MODEL_KEY, session)
+
+
+class RedeemClearsPriorStateTests(TestCase):
+    """R33/AE15: redeeming starts from a clean session, scope keys written last."""
+
+    def _redeem_over(self, session_state):
+        """Seed a session, then redeem a fresh link over it.
+
+        Args:
+            session_state: Mapping of session keys to seed before redeeming.
+
+        Returns:
+            The session after the redemption.
+        """
+        session = self.client.session
+        session.update(session_state)
+        session.save()
+        with gated_gate(), patch.object(model_access, "_now", return_value=1000.0):
+            token = model_access.mint_entry_link("dash")
+            resp = self.client.post(
+                gate_url(token), data={"credential": GATE_CREDENTIAL}
+            )
+        self.assertEqual(resp.status_code, 302)
+        return self.client.session
+
+    def test_redeem_clears_a_prior_user_model_selection(self):
+        session = self._redeem_over(
+            {"selected_model_type": "user_uploaded", "selected_model_id": "um-1"}
+        )
+        self.assertEqual(session[model_access.SCOPE_MODEL_KEY], "dash")
+        self.assertIsNone(session.get("selected_model_id"))
+
+    def test_redeem_clears_prior_classification_artifacts(self):
+        session = self._redeem_over(
+            {
+                "classify_dash_embedding": [0.0] * 1024,
+                "classify_results": {"best_matches": []},
+                "classify_model_type": "dash",
+            }
+        )
+        for key in (
+            "classify_dash_embedding",
+            "classify_results",
+            "classify_model_type",
+        ):
+            self.assertNotIn(key, session)
+
+
+class ScopeDeadlineTests(TestCase):
+    """R28/AE10: the stored deadline is absolute and immovable."""
+
+    def test_session_write_after_grant_does_not_move_the_deadline(self):
+        with gated_gate(), patch.object(model_access, "_now", return_value=1000.0):
+            token = model_access.mint_entry_link("dash")
+            self.client.post(gate_url(token), data={"credential": GATE_CREDENTIAL})
+            granted = self.client.session[model_access.SCOPE_DEADLINE_KEY]
+            # A later request that writes to the session must not re-arm the
+            # deadline: an idle-timeout implementation would.
+            with patch.object(model_access, "_now", return_value=2000.0):
+                self.client.get(reverse("astrodash:classify"))
+        self.assertEqual(self.client.session[model_access.SCOPE_DEADLINE_KEY], granted)
+        self.assertEqual(granted, 1000.0 + 3600)
+
+
+class MintCommandTests(TestCase):
+    """R10: minting is operator-only, and no route mints a link."""
+
+    def _mint_via_command(self, *args):
+        out = StringIO()
+        with gated_gate(), patch.object(model_access, "_now", return_value=1000.0):
+            call_command("mint_model_link", *args, stdout=out)
+        return out.getvalue().strip()
+
+    def test_command_prints_a_redeemable_link(self):
+        printed = self._mint_via_command("dash")
+        self.assertTrue(printed.startswith(GATE_LINK_BASE_URL), printed)
+        path = printed[len(GATE_LINK_BASE_URL) :]
+        with gated_gate(), patch.object(model_access, "_now", return_value=1001.0):
+            resp = self.client.get(path)
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn(CredentialPromptTests.PROMPT_MARKER, resp.content.decode())
+
+    def test_command_honors_an_explicit_window(self):
+        printed = self._mint_via_command("dash", "--ttl-seconds", "120")
+        token = printed.rstrip("/").rsplit("/", 1)[-1]
+        with gated_gate(), patch.object(model_access, "_now", return_value=1000.0):
+            link = model_access.redeem_entry_link(token)
+        self.assertEqual(link.expires_at, 1000.0 + 120)
+
+    def test_command_refuses_an_ungated_model(self):
+        with gate_configured():
+            with self.assertRaises(CommandError):
+                call_command("mint_model_link", "transformer", stdout=StringIO())
+
+    def test_command_refuses_an_unknown_model(self):
+        with gated_gate():
+            with self.assertRaises(CommandError):
+                call_command("mint_model_link", "no-such-model", stdout=StringIO())
+
+    def test_no_url_route_mints_a_link(self):
+        from astrodash import urls as astrodash_urls
+
+        names = [p.name for p in astrodash_urls.urlpatterns]
+        self.assertNotIn("mint_model_link", names)
+        for name in names:
+            self.assertNotIn("mint", name)
+        # The gate route exists, and it is the redeem side only.
+        self.assertIn("model_gate", names)
+
+    def test_command_without_a_link_base_url_fails_closed(self):
+        with gated_gate():
+            os.environ.pop(gate_config.LINK_BASE_URL_ENV_VAR, None)
+            with self.assertRaises(CommandError):
+                call_command("mint_model_link", "dash", stdout=StringIO())
+
+
+class SessionCookieSecurityTests(TestCase):
+    """The session now carries authorization, not just a preference."""
+
+    def test_session_cookie_is_marked_secure(self):
+        from django.conf import settings
+
+        self.assertTrue(settings.SESSION_COOKIE_SECURE)
+        # Pinned alongside the CSRF cookie's flag, which was already set.
+        self.assertTrue(settings.CSRF_COOKIE_SECURE)
+
+
+class RefusalCopyTests(TestCase):
+    """The refusal is the first thing an anonymous reviewer may ever see."""
+
+    def test_refusal_is_not_a_framework_default_error_page(self):
+        with gated_gate():
+            resp = self.client.get(gate_url("not-a-real-token"))
+        body = resp.content.decode()
+        self.assertEqual(resp.status_code, 403)
+        self.assertIn(CredentialPromptTests.REFUSAL_MARKER, body)
+        # Rendered through the site's own layout, not Django's bare 403 page.
+        self.assertNotIn("Forbidden</h1>", body)
+        self.assertTrue(re.search(r"<html", body, re.IGNORECASE))

--- a/app/astrodash/tests/test_model_access.py
+++ b/app/astrodash/tests/test_model_access.py
@@ -21,6 +21,7 @@ import re
 from contextlib import contextmanager
 from dataclasses import replace
 from io import StringIO
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from django.contrib.auth import get_user_model
@@ -578,6 +579,223 @@ class ScopeEnforcementTests(TestCase):
         with gated_gate(), patch.object(model_access, "_now", return_value=1001.0):
             resp = self.client.get(reverse("astrodash:classify"))
         self.assertEqual(resp.status_code, 200)
+
+
+class ScopeBoundaryTests(TestCase):
+    """R24/R29/R33/R35: what a scope may reach, and what ending it discards."""
+
+    END_CONTROL_MARKER = 'id="end-scope-button"'
+
+    def _redeem(self, now=1000.0, ttl_seconds="3600"):
+        with gated_gate(ttl_seconds=ttl_seconds), patch.object(
+            model_access, "_now", return_value=now
+        ):
+            token = model_access.mint_entry_link("dash")
+            resp = self.client.post(
+                gate_url(token), data={"credential": GATE_CREDENTIAL}
+            )
+        self.assertEqual(resp.status_code, 302)
+        return self.client.session[model_access.SCOPE_DEADLINE_KEY]
+
+    # --- a scope reaches classification only ---
+
+    def test_batch_flow_is_refused_for_a_scoped_session(self):
+        """AE8: a scoped session may enter the classification flow only."""
+        self._redeem()
+        with gated_gate(), patch.object(model_access, "_now", return_value=1001.0):
+            resp = self.client.get(reverse("astrodash:batch_process_ui"))
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(resp["Location"], reverse("astrodash:classify"))
+
+    def test_batch_refusal_surfaces_the_end_action(self):
+        self._redeem()
+        with gated_gate(), patch.object(model_access, "_now", return_value=1001.0):
+            resp = self.client.get(reverse("astrodash:batch_process_ui"), follow=True)
+        self.assertIn(self.END_CONTROL_MARKER, resp.content.decode())
+
+    def test_selection_page_is_refused_for_a_scoped_session(self):
+        self._redeem()
+        model_svc = MagicMock(list_models=AsyncMock(return_value=[]))
+        with gated_gate(), patch.object(
+            model_access, "_now", return_value=1001.0
+        ), patch("astrodash.ui_views.get_model_service", return_value=model_svc):
+            resp = self.client.get(reverse("astrodash:model_selection"))
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(resp["Location"], reverse("astrodash:classify"))
+
+    def test_selection_post_is_refused_for_a_scoped_session(self):
+        self._redeem()
+        model_svc = MagicMock(list_models=AsyncMock(return_value=[]))
+        with gated_gate(), patch.object(
+            model_access, "_now", return_value=1001.0
+        ), patch("astrodash.ui_views.get_model_service", return_value=model_svc):
+            resp = self.client.post(
+                reverse("astrodash:model_selection"),
+                data={"model_type": "transformer", "action_type": "classify"},
+            )
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(resp["Location"], reverse("astrodash:classify"))
+        session = self.client.session
+        self.assertEqual(session[model_access.SCOPE_MODEL_KEY], "dash")
+        # The POST did not move the selection either: a refused selection that
+        # still wrote the session would let a scope run a model it does not name.
+        self.assertEqual(session["selected_model_type"], "dash")
+
+    # --- the explicit end action ---
+
+    def test_end_control_renders_on_a_guarded_page_load(self):
+        self._redeem()
+        with gated_gate(), patch.object(model_access, "_now", return_value=1001.0):
+            resp = self.client.get(reverse("astrodash:classify"))
+        self.assertIn(self.END_CONTROL_MARKER, resp.content.decode())
+
+    def test_ending_the_scope_returns_to_the_public_picker(self):
+        self._redeem()
+        with gated_gate(), patch.object(model_access, "_now", return_value=1001.0):
+            resp = self.client.post(reverse("astrodash:end_model_scope"))
+        self.assertEqual(resp.status_code, 302)
+        self.assertTrue(
+            resp["Location"].startswith(reverse("astrodash:model_selection")),
+            resp["Location"],
+        )
+        self.assertNotIn(model_access.SCOPE_MODEL_KEY, self.client.session)
+
+    def test_ending_the_scope_discards_what_it_produced(self):
+        """AE12: a later twins request cannot be served from a retained embedding."""
+        self._redeem()
+        with gated_gate(), patch.object(
+            model_access, "_now", return_value=1001.0
+        ), mocked_classification("dash"):
+            self.client.post(reverse("astrodash:classify"), data=classify_post("dash"))
+        self.assertEqual(
+            self.client.session.get("classify_dash_embedding"), [0.0] * 1024
+        )
+        with gated_gate(), patch.object(model_access, "_now", return_value=1002.0):
+            self.client.post(reverse("astrodash:end_model_scope"))
+            resp = self.client.get(reverse("astrodash:twins_search"))
+        self.assertEqual(resp.status_code, 403)
+        self.assertNotIn("classify_dash_embedding", self.client.session)
+
+    def test_teardown_leaves_no_artifact_or_selection_key(self):
+        self._redeem()
+        session = self.client.session
+        session["classify_results"] = {"best_matches": []}
+        session["classify_model_type"] = "dash"
+        session.save()
+        with gated_gate(), patch.object(model_access, "_now", return_value=1001.0):
+            self.client.post(reverse("astrodash:end_model_scope"))
+        session = self.client.session
+        survivors = [k for k in session.keys() if k.startswith("classify_")]
+        self.assertEqual(survivors, [])
+        for key in (
+            model_access.SELECTION_SESSION_KEYS + model_access.SCOPE_SESSION_KEYS
+        ):
+            self.assertNotIn(key, session)
+
+    def test_teardown_leaves_an_authenticated_visitor_logged_in(self):
+        user = get_user_model().objects.create_user(
+            username="reviewer-2", password="not-the-gate-credential"
+        )
+        self.client.force_login(user)
+        self._redeem()
+        with gated_gate(), patch.object(model_access, "_now", return_value=1001.0):
+            self.client.post(reverse("astrodash:end_model_scope"))
+        self.assertEqual(self.client.session.get("_auth_user_id"), str(user.pk))
+
+    def test_end_action_is_idempotent_when_unscoped(self):
+        resp = self.client.post(reverse("astrodash:end_model_scope"))
+        self.assertEqual(resp.status_code, 302)
+        self.assertNotIn(model_access.SCOPE_MODEL_KEY, self.client.session)
+
+    def test_logout_leaves_no_scope_and_no_artifact_behind(self):
+        user = get_user_model().objects.create_user(
+            username="reviewer-3", password="not-the-gate-credential"
+        )
+        self.client.force_login(user)
+        self._redeem()
+        with gated_gate(), patch.object(
+            model_access, "_now", return_value=1001.0
+        ), mocked_classification("dash"):
+            self.client.post(reverse("astrodash:classify"), data=classify_post("dash"))
+        self.client.logout()
+        session = self.client.session
+        self.assertNotIn(model_access.SCOPE_MODEL_KEY, session)
+        self.assertEqual([k for k in session.keys() if k.startswith("classify_")], [])
+
+    # --- revalidation on entry ---
+
+    def test_public_session_whose_model_became_gated_is_turned_away(self):
+        """AE14: a stale selection cannot reach the gate."""
+        session = self.client.session
+        session["selected_model_type"] = "dash"
+        session.save()
+        with gated_gate(), patch.object(model_access, "_now", return_value=1000.0):
+            resp = self.client.get(reverse("astrodash:classify"))
+        self.assertEqual(resp.status_code, 302)
+        self.assertTrue(
+            resp["Location"].startswith(reverse("astrodash:model_selection")),
+            resp["Location"],
+        )
+        self.assertIsNone(self.client.session.get("selected_model_type"))
+
+    def test_public_session_whose_model_became_unlisted_is_turned_away_from_batch(self):
+        session = self.client.session
+        session["selected_model_type"] = "dash"
+        session.save()
+        unlisted = tuple(
+            replace(m, listed=False) if m.id == "dash" else m
+            for m in model_registry.MODELS
+        )
+        with patch.object(model_registry, "MODELS", unlisted):
+            resp = self.client.get(reverse("astrodash:batch_process_ui"))
+        self.assertEqual(resp.status_code, 302)
+        self.assertTrue(
+            resp["Location"].startswith(reverse("astrodash:model_selection")),
+            resp["Location"],
+        )
+
+    def test_scope_whose_model_was_published_dissolves_on_the_next_request(self):
+        self._redeem()
+        # No gated roster: the model has been published since the scope began.
+        with gate_configured(), patch.object(model_access, "_now", return_value=1001.0):
+            resp = self.client.get(reverse("astrodash:classify"))
+        session = self.client.session
+        self.assertEqual(resp.status_code, 200)
+        self.assertNotIn(model_access.SCOPE_MODEL_KEY, session)
+        self.assertEqual(session.get("selected_model_type"), "dash")
+        self.assertNotIn(
+            ScopeEnforcementTests.SCOPED_CONTROL_MARKER, resp.content.decode()
+        )
+
+    def test_user_uploaded_session_passes_revalidation_untouched(self):
+        session = self.client.session
+        session["selected_model_type"] = "user_uploaded"
+        session["selected_model_id"] = "um-1"
+        session.save()
+        model_svc = MagicMock(
+            get_model=AsyncMock(return_value=SimpleNamespace(name="My model"))
+        )
+        with patch("astrodash.ui_views.get_model_service", return_value=model_svc):
+            classify_resp = self.client.get(reverse("astrodash:classify"))
+            batch_resp = self.client.get(reverse("astrodash:batch_process_ui"))
+        self.assertEqual(classify_resp.status_code, 200)
+        self.assertEqual(batch_resp.status_code, 200)
+        self.assertEqual(self.client.session["selected_model_type"], "user_uploaded")
+
+    # --- the two refusals speak to different audiences ---
+
+    def test_lapsed_refusal_says_the_window_ended_while_a_cold_link_does_not(self):
+        deadline = self._redeem()
+        with gated_gate(), patch.object(
+            model_access, "_now", return_value=deadline + 1
+        ):
+            lapsed = self.client.get(reverse("astrodash:classify"))
+        with gated_gate(), patch.object(model_access, "_now", return_value=1000.0):
+            cold = self.client.get(gate_url("not-a-real-token"))
+        lapsed_body = lapsed.content.decode()
+        cold_body = cold.content.decode()
+        self.assertIn(model_access.SCOPE_LAPSED_HEADING, lapsed_body)
+        self.assertNotIn(model_access.SCOPE_LAPSED_HEADING, cold_body)
 
 
 class UngatedFlowUnaffectedTests(TestCase):

--- a/app/astrodash/tests/test_model_registry.py
+++ b/app/astrodash/tests/test_model_registry.py
@@ -6,11 +6,13 @@ any read site consumes it. They are pure in-memory tests: no database, no model
 weights.
 """
 
+import os
 from dataclasses import replace
 from unittest.mock import patch
 
-from django.test import SimpleTestCase
+from django.test import SimpleTestCase, override_settings
 
+from astrodash.core import gate_config
 from astrodash.infrastructure.ml import model_registry as registry
 from astrodash.infrastructure.ml.classifiers.dash_classifier import DashClassifier
 from astrodash.infrastructure.ml.classifiers.transformer_classifier import (
@@ -102,3 +104,169 @@ class InvariantTests(SimpleTestCase):
     def test_production_registry_is_valid(self):
         # Should not raise.
         registry.validate_registry(registry.MODELS)
+
+    def test_gated_and_listed_raises(self):
+        """R26: a model requiring a credential may never be listed."""
+        transformer = registry.get_definition("transformer")
+        dash = registry.get_definition("dash")
+        gated_but_listed = replace(dash, requires_credential=True, listed=True)
+        with self.assertRaises(ValueError) as ctx:
+            registry.validate_registry((transformer, gated_but_listed))
+        self.assertIn("dash", str(ctx.exception))
+
+    def test_gated_default_raises(self):
+        """R26: the active default may never require a credential."""
+        transformer = registry.get_definition("transformer")
+        gated_default = replace(transformer, requires_credential=True, listed=False)
+        with self.assertRaises(ValueError) as ctx:
+            registry.validate_registry((gated_default,))
+        self.assertIn("transformer", str(ctx.exception))
+
+    def test_unlisted_default_raises(self):
+        """R26: the active default is always listed."""
+        transformer = registry.get_definition("transformer")
+        dash = registry.get_definition("dash")
+        unlisted_default = replace(transformer, listed=False)
+        with self.assertRaises(ValueError) as ctx:
+            registry.validate_registry((unlisted_default, dash))
+        self.assertIn("transformer", str(ctx.exception))
+
+
+class ListingTests(SimpleTestCase):
+    """R1/KD1: listing is independent of lifecycle status."""
+
+    def test_unlisted_active_model_drops_from_listed_only(self):
+        transformer = registry.get_definition("transformer")
+        dash = registry.get_definition("dash")
+        unlisted_dash = replace(dash, listed=False)
+        patched = (transformer, unlisted_dash)
+
+        with patch.object(registry, "MODELS", patched):
+            self.assertEqual(
+                [d.id for d in registry.active_definitions()],
+                ["transformer", "dash"],
+            )
+            self.assertEqual(
+                [d.id for d in registry.listed_definitions()],
+                ["transformer"],
+            )
+
+    def test_retired_model_drops_from_active_and_listed(self):
+        transformer = registry.get_definition("transformer")
+        dash = registry.get_definition("dash")
+        retired_dash = replace(dash, status=registry.STATUS_RETIRED)
+        patched = (transformer, retired_dash)
+
+        with patch.object(registry, "MODELS", patched):
+            self.assertEqual(
+                [d.id for d in registry.active_definitions()], ["transformer"]
+            )
+            self.assertEqual(
+                [d.id for d in registry.listed_definitions()], ["transformer"]
+            )
+
+    def test_builtin_models_are_listed_and_ungated(self):
+        for model_id in ("dash", "transformer"):
+            with self.subTest(model=model_id):
+                definition = registry.get_definition(model_id)
+                self.assertTrue(definition.listed)
+                self.assertFalse(definition.requires_credential)
+
+
+class RedshiftInputPolicyTests(SimpleTestCase):
+    """R13/R15/KD5: a three-way input policy, with the old boolean derived."""
+
+    def test_builtin_policies_match_todays_semantics(self):
+        dash = registry.get_definition("dash")
+        transformer = registry.get_definition("transformer")
+        self.assertEqual(dash.redshift_input, registry.REDSHIFT_INPUT_OPTIONAL)
+        self.assertEqual(transformer.redshift_input, registry.REDSHIFT_INPUT_REQUIRED)
+        # The derived property still answers exactly as the field used to.
+        self.assertFalse(dash.requires_redshift)
+        self.assertTrue(transformer.requires_redshift)
+
+    def test_declining_redshift_is_not_requiring_it(self):
+        dash = registry.get_definition("dash")
+        no_redshift = replace(dash, redshift_input=registry.REDSHIFT_INPUT_NONE)
+        self.assertFalse(no_redshift.requires_redshift)
+        # R15: declining redshift as an input says nothing about estimating one.
+        self.assertTrue(no_redshift.supports_redshift_estimation)
+
+
+class GateConfigurationTests(SimpleTestCase):
+    """R34/AE13: a gated model with unconfigured gate configuration fails closed."""
+
+    def _gated_roster(self):
+        transformer = registry.get_definition("transformer")
+        dash = registry.get_definition("dash")
+        gated = replace(dash, requires_credential=True, listed=False)
+        return (transformer, gated)
+
+    def _configured_env(self, **overrides):
+        env = {
+            gate_config.CREDENTIAL_ENV_VAR: "a-shared-credential",
+            gate_config.LINK_TTL_ENV_VAR: "604800",
+        }
+        env.update(overrides)
+        return env
+
+    def test_missing_credential_is_rejected_naming_the_configuration(self):
+        env = self._configured_env()
+        del env[gate_config.CREDENTIAL_ENV_VAR]
+        with patch.dict(os.environ, env, clear=True), override_settings(
+            SECRET_KEY="a-real-signing-key"
+        ):
+            configuration = gate_config.gate_configuration()
+        with self.assertRaises(ValueError) as ctx:
+            registry.validate_gate_configuration(self._gated_roster(), configuration)
+        self.assertIn(gate_config.CREDENTIAL_ENV_VAR, str(ctx.exception))
+
+    def test_blank_credential_is_rejected(self):
+        for blank in ("", "   ", "\t\n"):
+            with self.subTest(credential=repr(blank)):
+                env = self._configured_env(**{gate_config.CREDENTIAL_ENV_VAR: blank})
+                with patch.dict(os.environ, env, clear=True), override_settings(
+                    SECRET_KEY="a-real-signing-key"
+                ):
+                    configuration = gate_config.gate_configuration()
+                with self.assertRaises(ValueError) as ctx:
+                    registry.validate_gate_configuration(
+                        self._gated_roster(), configuration
+                    )
+                self.assertIn(gate_config.CREDENTIAL_ENV_VAR, str(ctx.exception))
+
+    def test_committed_default_signing_key_is_rejected(self):
+        with patch.dict(
+            os.environ, self._configured_env(), clear=True
+        ), override_settings(SECRET_KEY="django-insecure-committed-default"):
+            configuration = gate_config.gate_configuration()
+        with self.assertRaises(ValueError) as ctx:
+            registry.validate_gate_configuration(self._gated_roster(), configuration)
+        self.assertIn(gate_config.SIGNING_KEY_NAME, str(ctx.exception))
+
+    def test_missing_expiry_window_is_rejected(self):
+        env = self._configured_env()
+        del env[gate_config.LINK_TTL_ENV_VAR]
+        with patch.dict(os.environ, env, clear=True), override_settings(
+            SECRET_KEY="a-real-signing-key"
+        ):
+            configuration = gate_config.gate_configuration()
+        with self.assertRaises(ValueError) as ctx:
+            registry.validate_gate_configuration(self._gated_roster(), configuration)
+        self.assertIn(gate_config.LINK_TTL_ENV_VAR, str(ctx.exception))
+
+    def test_fully_configured_gate_passes(self):
+        with patch.dict(
+            os.environ, self._configured_env(), clear=True
+        ), override_settings(SECRET_KEY="a-real-signing-key"):
+            configuration = gate_config.gate_configuration()
+        # Should not raise.
+        registry.validate_gate_configuration(self._gated_roster(), configuration)
+
+    def test_ungated_roster_passes_with_no_gate_configuration(self):
+        with patch.dict(os.environ, {}, clear=True), override_settings(
+            SECRET_KEY="django-insecure-committed-default"
+        ):
+            configuration = gate_config.gate_configuration()
+        # Should not raise: nothing in the shipped roster is gated.
+        registry.validate_gate_configuration(registry.MODELS, configuration)

--- a/app/astrodash/tests/test_model_registry.py
+++ b/app/astrodash/tests/test_model_registry.py
@@ -34,7 +34,7 @@ class DefinitionFieldsTests(SimpleTestCase):
     def test_dash_capability_fields(self):
         dash = registry.get_definition("dash")
         self.assertIsNotNone(dash)
-        self.assertFalse(dash.requires_redshift)
+        self.assertEqual(dash.redshift_input, registry.REDSHIFT_INPUT_OPTIONAL)
         self.assertTrue(dash.supports_twins)
         self.assertTrue(dash.supports_redshift_estimation)
         self.assertTrue(dash.supports_template_overlays)
@@ -46,7 +46,7 @@ class DefinitionFieldsTests(SimpleTestCase):
     def test_transformer_capability_fields(self):
         tr = registry.get_definition("transformer")
         self.assertIsNotNone(tr)
-        self.assertTrue(tr.requires_redshift)
+        self.assertEqual(tr.redshift_input, registry.REDSHIFT_INPUT_REQUIRED)
         self.assertFalse(tr.supports_twins)
         self.assertFalse(tr.supports_redshift_estimation)
         self.assertFalse(tr.supports_template_overlays)
@@ -175,22 +175,39 @@ class ListingTests(SimpleTestCase):
 
 
 class RedshiftInputPolicyTests(SimpleTestCase):
-    """R13/R15/KD5: a three-way input policy, with the old boolean derived."""
+    """R13/R15/KD5: redshift input is a three-way policy, and the sole authority."""
 
     def test_builtin_policies_match_todays_semantics(self):
         dash = registry.get_definition("dash")
         transformer = registry.get_definition("transformer")
         self.assertEqual(dash.redshift_input, registry.REDSHIFT_INPUT_OPTIONAL)
         self.assertEqual(transformer.redshift_input, registry.REDSHIFT_INPUT_REQUIRED)
-        # The derived property still answers exactly as the field used to.
-        self.assertFalse(dash.requires_redshift)
-        self.assertTrue(transformer.requires_redshift)
+
+    def test_the_three_policies_are_distinct(self):
+        self.assertEqual(
+            len(
+                {
+                    registry.REDSHIFT_INPUT_REQUIRED,
+                    registry.REDSHIFT_INPUT_OPTIONAL,
+                    registry.REDSHIFT_INPUT_NONE,
+                }
+            ),
+            3,
+        )
+
+    def test_no_derived_redshift_boolean_remains(self):
+        """KTD12: the boolean the policy replaced is gone, not shadowing it."""
+        dash = registry.get_definition("dash")
+        self.assertFalse(hasattr(dash, "requires_redshift"))
 
     def test_declining_redshift_is_not_requiring_it(self):
         dash = registry.get_definition("dash")
         no_redshift = replace(dash, redshift_input=registry.REDSHIFT_INPUT_NONE)
-        self.assertFalse(no_redshift.requires_redshift)
-        # R15: declining redshift as an input says nothing about estimating one.
+        self.assertNotEqual(
+            no_redshift.redshift_input, registry.REDSHIFT_INPUT_REQUIRED
+        )
+        # R15/AE5: declining redshift as an input says nothing about estimating
+        # one -- the model still produces a redshift estimate.
         self.assertTrue(no_redshift.supports_redshift_estimation)
 
 

--- a/app/astrodash/tests/test_model_registry.py
+++ b/app/astrodash/tests/test_model_registry.py
@@ -35,7 +35,7 @@ class DefinitionFieldsTests(SimpleTestCase):
         dash = registry.get_definition("dash")
         self.assertIsNotNone(dash)
         self.assertEqual(dash.redshift_input, registry.REDSHIFT_INPUT_OPTIONAL)
-        self.assertTrue(dash.supports_twins)
+        self.assertIn(registry.SURFACE_DASH_TWINS, dash.surfaces)
         self.assertTrue(dash.supports_redshift_estimation)
         self.assertTrue(dash.supports_template_overlays)
         self.assertTrue(dash.supports_rlap)
@@ -47,7 +47,7 @@ class DefinitionFieldsTests(SimpleTestCase):
         tr = registry.get_definition("transformer")
         self.assertIsNotNone(tr)
         self.assertEqual(tr.redshift_input, registry.REDSHIFT_INPUT_REQUIRED)
-        self.assertFalse(tr.supports_twins)
+        self.assertNotIn(registry.SURFACE_DASH_TWINS, tr.surfaces)
         self.assertFalse(tr.supports_redshift_estimation)
         self.assertFalse(tr.supports_template_overlays)
         self.assertFalse(tr.supports_rlap)
@@ -238,34 +238,31 @@ class SurfaceDeclarationTests(SimpleTestCase):
             ["Classification"],
         )
 
-    def test_derived_twins_property_agrees_with_the_declared_list(self):
-        for model_id, declares_twins in (("dash", True), ("transformer", False)):
-            with self.subTest(model=model_id):
-                definition = registry.get_definition(model_id)
-                self.assertEqual(definition.supports_twins, declares_twins)
-                self.assertEqual(
-                    registry.SURFACE_DASH_TWINS in definition.surfaces,
-                    declares_twins,
-                )
-
     def test_declared_list_is_the_sole_authority_for_twins(self):
-        """R31: flipping the declared list flips the derived twins answer."""
+        """R31: the declared list is the only place twins is answered.
+
+        The transitional ``supports_twins`` property is gone (KTD12: U5 owned
+        its read site and deleted it), so membership in ``surfaces`` is the
+        whole answer -- and flipping the list flips it.
+        """
+        self.assertFalse(hasattr(registry.get_definition("dash"), "supports_twins"))
+
         transformer = registry.get_definition("transformer")
         gains_twins = replace(
             transformer,
             surfaces=(registry.SURFACE_CLASSIFICATION, registry.SURFACE_DASH_TWINS),
         )
-        self.assertTrue(gains_twins.supports_twins)
+        self.assertIn(registry.SURFACE_DASH_TWINS, gains_twins.surfaces)
 
         dash = registry.get_definition("dash")
         loses_twins = replace(dash, surfaces=(registry.SURFACE_CLASSIFICATION,))
-        self.assertFalse(loses_twins.supports_twins)
+        self.assertNotIn(registry.SURFACE_DASH_TWINS, loses_twins.surfaces)
 
     def test_capability_booleans_are_independent_of_the_surface_list(self):
         """R30/KTD11: overlay, RLap, and redshift-estimation stay booleans."""
         dash = registry.get_definition("dash")
         no_twins_surface = replace(dash, surfaces=(registry.SURFACE_CLASSIFICATION,))
-        self.assertFalse(no_twins_surface.supports_twins)
+        self.assertNotIn(registry.SURFACE_DASH_TWINS, no_twins_surface.surfaces)
         self.assertTrue(no_twins_surface.supports_redshift_estimation)
         self.assertTrue(no_twins_surface.supports_template_overlays)
         self.assertTrue(no_twins_surface.supports_rlap)

--- a/app/astrodash/tests/test_model_registry.py
+++ b/app/astrodash/tests/test_model_registry.py
@@ -12,6 +12,7 @@ from unittest.mock import patch
 
 from django.test import SimpleTestCase, override_settings
 
+from astrodash import surfaces
 from astrodash.core import gate_config
 from astrodash.infrastructure.ml import model_registry as registry
 from astrodash.infrastructure.ml.classifiers.dash_classifier import DashClassifier
@@ -191,6 +192,138 @@ class RedshiftInputPolicyTests(SimpleTestCase):
         self.assertFalse(no_redshift.requires_redshift)
         # R15: declining redshift as an input says nothing about estimating one.
         self.assertTrue(no_redshift.supports_redshift_estimation)
+
+
+class SurfaceDeclarationTests(SimpleTestCase):
+    """R16/R18/R31/KD4: result surfaces are a declared, ordered list."""
+
+    def test_dash_declares_classification_then_dash_twins(self):
+        dash = registry.get_definition("dash")
+        self.assertEqual(
+            list(dash.surfaces),
+            [registry.SURFACE_CLASSIFICATION, registry.SURFACE_DASH_TWINS],
+        )
+
+    def test_transformer_declares_classification_only(self):
+        transformer = registry.get_definition("transformer")
+        self.assertEqual(list(transformer.surfaces), [registry.SURFACE_CLASSIFICATION])
+
+    def test_declared_surfaces_resolve_in_declared_order(self):
+        """AE7: DASH resolves both surfaces in order, Transformer only one."""
+        dash = registry.get_definition("dash")
+        transformer = registry.get_definition("transformer")
+        self.assertEqual(
+            [s.title for s in surfaces.resolve_surfaces(dash.surfaces)],
+            ["Classification", "DASH Twins"],
+        )
+        self.assertEqual(
+            [s.title for s in surfaces.resolve_surfaces(transformer.surfaces)],
+            ["Classification"],
+        )
+
+    def test_derived_twins_property_agrees_with_the_declared_list(self):
+        for model_id, declares_twins in (("dash", True), ("transformer", False)):
+            with self.subTest(model=model_id):
+                definition = registry.get_definition(model_id)
+                self.assertEqual(definition.supports_twins, declares_twins)
+                self.assertEqual(
+                    registry.SURFACE_DASH_TWINS in definition.surfaces,
+                    declares_twins,
+                )
+
+    def test_declared_list_is_the_sole_authority_for_twins(self):
+        """R31: flipping the declared list flips the derived twins answer."""
+        transformer = registry.get_definition("transformer")
+        gains_twins = replace(
+            transformer,
+            surfaces=(registry.SURFACE_CLASSIFICATION, registry.SURFACE_DASH_TWINS),
+        )
+        self.assertTrue(gains_twins.supports_twins)
+
+        dash = registry.get_definition("dash")
+        loses_twins = replace(dash, surfaces=(registry.SURFACE_CLASSIFICATION,))
+        self.assertFalse(loses_twins.supports_twins)
+
+    def test_capability_booleans_are_independent_of_the_surface_list(self):
+        """R30/KTD11: overlay, RLap, and redshift-estimation stay booleans."""
+        dash = registry.get_definition("dash")
+        no_twins_surface = replace(dash, surfaces=(registry.SURFACE_CLASSIFICATION,))
+        self.assertFalse(no_twins_surface.supports_twins)
+        self.assertTrue(no_twins_surface.supports_redshift_estimation)
+        self.assertTrue(no_twins_surface.supports_template_overlays)
+        self.assertTrue(no_twins_surface.supports_rlap)
+
+
+class SurfaceValidationTests(SimpleTestCase):
+    """R16/R17: a declared surface list is validated against the known ids."""
+
+    def _known_ids(self):
+        return surfaces.known_surface_ids()
+
+    def test_unknown_surface_id_is_rejected(self):
+        transformer = registry.get_definition("transformer")
+        dash = registry.get_definition("dash")
+        bogus = replace(
+            dash, surfaces=(registry.SURFACE_CLASSIFICATION, "no_such_surface")
+        )
+        with self.assertRaises(ValueError) as ctx:
+            registry.validate_surfaces((transformer, bogus), self._known_ids())
+        self.assertIn("no_such_surface", str(ctx.exception))
+        self.assertIn("dash", str(ctx.exception))
+
+    def test_empty_surface_list_is_rejected(self):
+        transformer = registry.get_definition("transformer")
+        dash = registry.get_definition("dash")
+        empty = replace(dash, surfaces=())
+        with self.assertRaises(ValueError) as ctx:
+            registry.validate_surfaces((transformer, empty), self._known_ids())
+        self.assertIn("dash", str(ctx.exception))
+
+    def test_surface_list_omitting_classification_is_rejected(self):
+        transformer = registry.get_definition("transformer")
+        dash = registry.get_definition("dash")
+        twins_only = replace(dash, surfaces=(registry.SURFACE_DASH_TWINS,))
+        with self.assertRaises(ValueError) as ctx:
+            registry.validate_surfaces((transformer, twins_only), self._known_ids())
+        self.assertIn(registry.SURFACE_CLASSIFICATION, str(ctx.exception))
+        self.assertIn("dash", str(ctx.exception))
+
+    def test_production_registry_declares_only_known_surfaces(self):
+        # Should not raise: this is the check the app-ready hook runs.
+        registry.validate_surfaces(registry.MODELS, self._known_ids())
+
+
+class SurfaceMapTests(SimpleTestCase):
+    """R30/KTD11: the web layer maps a surface id to its presentation."""
+
+    def test_every_declared_id_resolves_through_the_map(self):
+        for definition in registry.MODELS:
+            with self.subTest(model=definition.id):
+                resolved = surfaces.resolve_surfaces(definition.surfaces)
+                self.assertEqual([s.id for s in resolved], list(definition.surfaces))
+
+    def test_pane_identity_reproduces_todays_tab_markup(self):
+        classification = surfaces.get_surface(registry.SURFACE_CLASSIFICATION)
+        self.assertEqual(classification.tab_id, "classification-tab")
+        self.assertEqual(classification.pane_id, "classification-pane")
+
+        twins = surfaces.get_surface(registry.SURFACE_DASH_TWINS)
+        self.assertEqual(twins.tab_id, "twins-tab")
+        self.assertEqual(twins.pane_id, "twins-pane")
+        self.assertEqual(twins.title, "DASH Twins")
+
+    def test_twins_surface_owns_the_twins_supporting_routes(self):
+        twins = surfaces.get_surface(registry.SURFACE_DASH_TWINS)
+        self.assertEqual(
+            sorted(twins.routes),
+            ["dash_twins", "dash_twins_data", "twins_search"],
+        )
+
+    def test_unknown_surface_id_does_not_resolve(self):
+        self.assertIsNone(surfaces.get_surface("no_such_surface"))
+        with self.assertRaises(ValueError) as ctx:
+            surfaces.resolve_surfaces(("no_such_surface",))
+        self.assertIn("no_such_surface", str(ctx.exception))
 
 
 class GateConfigurationTests(SimpleTestCase):

--- a/app/astrodash/tests/test_no_model_type_literals.py
+++ b/app/astrodash/tests/test_no_model_type_literals.py
@@ -257,6 +257,20 @@ def _is_gated(view) -> bool:
     return getattr(view, "model_access_guarded", False) is True
 
 
+def _gated_route(view):
+    """Return the route name a view's gate is bound to.
+
+    Args:
+        view: The resolved view callable.
+
+    Returns:
+        The route name the gate authorizes against, or ``None`` -- which is both
+        the classification view's correct value and what an unguarded view
+        returns, so callers check :func:`_is_gated` first.
+    """
+    return getattr(view, "model_access_route", None)
+
+
 class GateCoverageTests(SimpleTestCase):
     """R9: every route the surface map declares carries the gate.
 
@@ -290,6 +304,26 @@ class GateCoverageTests(SimpleTestCase):
             "These routes can run a model without consulting the access gate. "
             "Apply @model_access_required to each: " + ", ".join(unguarded),
         )
+
+    def test_every_surface_route_gate_is_bound_to_that_route(self) -> None:
+        """A gate applied without its route name skips the surface check."""
+        misbound = []
+        for surface in SURFACES.values():
+            for name in surface.routes:
+                view = resolve(reverse(f"astrodash:{name}")).func
+                if _gated_route(view) != name:
+                    misbound.append(f"{name} (bound to {_gated_route(view)!r})")
+        self.assertFalse(
+            misbound,
+            "These surface routes carry the gate but not their own route name, "
+            "so the gate never checks that the model declares the surface: "
+            + ", ".join(misbound),
+        )
+
+    def test_the_classification_view_is_the_one_route_with_no_route_name(self) -> None:
+        view = resolve(reverse("astrodash:classify")).func
+        self.assertTrue(_is_gated(view))
+        self.assertIsNone(_gated_route(view))
 
     def test_the_guard_would_flag_an_unguarded_view(self) -> None:
         def plain_view(request):  # pragma: no cover - never called
@@ -350,9 +384,23 @@ class ScopedFlowSessionKeyTests(TestCase):
             model_access, "_now", return_value=1001.0
         ), mocked_classification("dash"):
             self.client.get(reverse("astrodash:classify"))
-            self.client.post(reverse("astrodash:classify"), data=classify_post("dash"))
+            classified = self.client.post(
+                reverse("astrodash:classify"), data=classify_post("dash")
+            )
         with gated_gate(), patch.object(model_access, "_now", return_value=1002.0):
             self.client.get(reverse("astrodash:dash_twins"))
+        # Positive control: without it, a scoped flow that silently stopped
+        # working would satisfy every absence assertion below.
+        self.assertEqual(classified.status_code, 200)
+        self.assertTrue(
+            [
+                k
+                for k in self.client.session.keys()
+                if k.startswith(model_access.ARTIFACT_KEY_PREFIX)
+            ],
+            "the scoped flow wrote no classification artifact, so the sweep "
+            "assertions below would pass vacuously",
+        )
 
     def test_scoped_flow_writes_no_unsweepable_session_key(self) -> None:
         self._run_scoped_flow()

--- a/app/astrodash/tests/test_no_model_type_literals.py
+++ b/app/astrodash/tests/test_no_model_type_literals.py
@@ -1,4 +1,21 @@
-"""Regression guard: no model-defining model_type literals in the gate files.
+"""Regression guards over the registry-driven model surface.
+
+Three properties are enforced here, each of them a thing a later edit can undo
+silently:
+
+1. No model-defining ``model_type`` literal in the gate files -- now including
+   the classification and batch templates and the access module, because a
+   per-model conditional in a template is exactly as damaging as one in Python
+   and the original scan could not see it.
+2. Every route the surface map declares carries the access gate. The gate is a
+   decorator and therefore opt-in: a surface added later could omit it and
+   nothing would fail.
+3. A view reachable in a scoped flow writes no session key outside the swept
+   namespaces. Teardown sweeps the artifact prefix and the enumerated scope and
+   selection keys; an artifact stored anywhere else survives a teardown that
+   was never going to look for it.
+
+Regression guard: no model-defining model_type literals in the gate files.
 
 This refactor replaced the scattered ``model_type == 'dash'`` /
 ``== 'transformer'`` branches with reads against the model registry's
@@ -28,17 +45,44 @@ import re
 from pathlib import Path
 from typing import List, Tuple
 
-from django.test import SimpleTestCase
+from django.test import SimpleTestCase, TestCase
+from django.urls import resolve, reverse
+from unittest.mock import patch
+
+from astrodash.core import model_access
+from astrodash.surfaces import SURFACES
+from astrodash.tests.gate_fixtures import (
+    GATE_CREDENTIAL,
+    classify_post,
+    gate_url,
+    gated_gate,
+    mocked_classification,
+)
 
 # app/ -- tests/ is app/astrodash/tests/, so parent.parent.parent is app/.
 APP_ROOT = Path(__file__).resolve().parent.parent.parent
 
-# The gate files this refactor routed through the model registry (U5).
+# The gate files routed through the model registry: the Python gates (U5) plus
+# the two templates and the access module the surface and gate work added.
+# Templates are scanned because a per-model conditional there is invisible to a
+# Python-only scan, which is exactly where three of them used to live.
 GATE_FILES = (
     "astrodash/forms.py",
     "astrodash/ui_views.py",
+    "astrodash/core/model_access.py",
     "astrodash/domain/services/spectrum_processing_service.py",
     "astrodash/domain/services/redshift_service.py",
+    "astrodash/templates/astrodash/classify.html",
+    "astrodash/templates/astrodash/batch.html",
+)
+
+# Comment syntaxes a template can carry. Their contents are blanked before the
+# scan, so a commented-out example does not trip the guard -- while keeping line
+# numbers intact, so a real hit still reports where it is.
+TEMPLATE_COMMENT_PATTERNS = (
+    re.compile(r"<!--.*?-->", re.DOTALL),
+    re.compile(r"\{#.*?#\}", re.DOTALL),
+    re.compile(r"\{%\s*comment\s*.*?%\}.*?\{%\s*endcomment\s*%\}", re.DOTALL),
 )
 
 # A conditional comparison of a value against a quoted built-in model id, in
@@ -64,6 +108,25 @@ def _is_exempt(line: str) -> bool:
     return "preprocessing ==" in line
 
 
+def _strip_template_comments(text: str) -> str:
+    """Blank out template comment bodies, preserving line structure.
+
+    Args:
+        text: The template source.
+
+    Returns:
+        The source with every comment's characters replaced by spaces and its
+        newlines kept, so line numbers still line up with the file.
+    """
+
+    def blank(match: "re.Match[str]") -> str:
+        return re.sub(r"[^\n]", " ", match.group(0))
+
+    for pattern in TEMPLATE_COMMENT_PATTERNS:
+        text = pattern.sub(blank, text)
+    return text
+
+
 def _scan_file(path: Path) -> List[Tuple[int, str]]:
     """Scan one file for model-defining model_type comparison literals.
 
@@ -76,6 +139,8 @@ def _scan_file(path: Path) -> List[Tuple[int, str]]:
     """
     hits: List[Tuple[int, str]] = []
     text = path.read_text(encoding="utf-8")
+    if path.suffix == ".html":
+        text = _strip_template_comments(text)
     for lineno, line in enumerate(text.splitlines(), start=1):
         if _is_exempt(line):
             continue
@@ -147,3 +212,174 @@ class GuardPatternsTests(SimpleTestCase):
         self.assertFalse(
             self._flags("            model_type: Type of model ('dash', 'transformer')")
         )
+
+    # --- template comments: stripped before the scan ---
+
+    def test_commented_out_literal_in_a_template_does_not_trip_the_guard(self) -> None:
+        for comment in (
+            "<!-- {% if model_type == 'dash' %} -->",
+            "{# {% if model_type == 'dash' %} #}",
+            "{% comment %}{% if model_type == 'dash' %}{% endcomment %}",
+        ):
+            stripped = _strip_template_comments(comment)
+            self.assertFalse(
+                COMPARISON_PATTERN.search(stripped),
+                f"comment was not stripped: {comment}",
+            )
+
+    def test_a_live_template_literal_still_trips_the_guard(self) -> None:
+        live = "{% if selected_model_type == 'dash' %}"
+        self.assertTrue(COMPARISON_PATTERN.search(_strip_template_comments(live)))
+
+    def test_comment_stripping_preserves_line_numbers(self) -> None:
+        source = "a\n<!-- one\ntwo -->\n{% if model_type == 'dash' %}\n"
+        stripped = _strip_template_comments(source)
+        self.assertEqual(len(stripped.splitlines()), len(source.splitlines()))
+        hit = [
+            lineno
+            for lineno, line in enumerate(stripped.splitlines(), start=1)
+            if COMPARISON_PATTERN.search(line)
+        ]
+        self.assertEqual(hit, [4])
+
+
+def _is_gated(view) -> bool:
+    """Whether a view carries the model-access gate.
+
+    Args:
+        view: The resolved view callable.
+
+    Returns:
+        True when the gate decorator's marker is present. ``functools.wraps``
+        copies it outward, so a decorator stacked above the gate does not hide
+        it.
+    """
+    return getattr(view, "model_access_guarded", False) is True
+
+
+class GateCoverageTests(SimpleTestCase):
+    """R9: every route the surface map declares carries the gate.
+
+    A decorator is opt-in by nature, so "a surface added later cannot silently
+    omit the check" is only true if something checks. This is that something:
+    it walks the surface map rather than a hand-written list, so registering a
+    surface with an unguarded route fails here rather than in production.
+    """
+
+    def _guarded_route_names(self):
+        """Return every route name that must carry the gate.
+
+        Returns:
+            list: The supporting routes of every registered surface, plus the
+            classification view itself, which owns no supporting route but can
+            run a model directly.
+        """
+        names = ["classify"]
+        for surface in SURFACES.values():
+            names.extend(surface.routes)
+        return names
+
+    def test_every_declared_surface_route_carries_the_gate(self) -> None:
+        unguarded = []
+        for name in self._guarded_route_names():
+            view = resolve(reverse(f"astrodash:{name}")).func
+            if not _is_gated(view):
+                unguarded.append(name)
+        self.assertFalse(
+            unguarded,
+            "These routes can run a model without consulting the access gate. "
+            "Apply @model_access_required to each: " + ", ".join(unguarded),
+        )
+
+    def test_the_guard_would_flag_an_unguarded_view(self) -> None:
+        def plain_view(request):  # pragma: no cover - never called
+            return None
+
+        self.assertFalse(_is_gated(plain_view))
+
+    def test_the_guard_sees_through_a_stacked_decorator(self) -> None:
+        # dash_twins carries @xframe_options_sameorigin above the gate; if the
+        # marker did not survive that, this guard would be vacuously true.
+        from astrodash import ui_views
+
+        self.assertTrue(_is_gated(ui_views.dash_twins))
+
+
+# Session keys the scoped flow may write: the scope, the selection, and the
+# classification-artifact namespace teardown sweeps. Django owns the
+# underscore-prefixed namespace (session expiry, auth, messages), which teardown
+# deliberately leaves alone.
+ALLOWED_SESSION_KEYS = (
+    model_access.SCOPE_SESSION_KEYS + model_access.SELECTION_SESSION_KEYS
+)
+
+
+def _unsweepable_session_keys(session) -> List[str]:
+    """Return session keys a teardown would leave behind.
+
+    Args:
+        session: The session (or any key-bearing mapping) to inspect.
+
+    Returns:
+        Every key that is neither Django's own, nor one teardown enumerates,
+        nor inside the artifact prefix it sweeps.
+    """
+    return sorted(
+        key
+        for key in session.keys()
+        if not key.startswith("_")
+        and key not in ALLOWED_SESSION_KEYS
+        and not key.startswith(model_access.ARTIFACT_KEY_PREFIX)
+    )
+
+
+class ScopedFlowSessionKeyTests(TestCase):
+    """R33: nothing a scoped flow writes can escape the teardown sweep.
+
+    The sweep already covers anything added under the artifact prefix, so the
+    escape route is an artifact stored *outside* it, where the sweep will never
+    reach. This drives the whole scoped flow and asserts no such key appears.
+    """
+
+    def _run_scoped_flow(self):
+        """Redeem a link, classify, and browse the surfaces it declares."""
+        with gated_gate(), patch.object(model_access, "_now", return_value=1000.0):
+            token = model_access.mint_entry_link("dash")
+            self.client.post(gate_url(token), data={"credential": GATE_CREDENTIAL})
+        with gated_gate(), patch.object(
+            model_access, "_now", return_value=1001.0
+        ), mocked_classification("dash"):
+            self.client.get(reverse("astrodash:classify"))
+            self.client.post(reverse("astrodash:classify"), data=classify_post("dash"))
+        with gated_gate(), patch.object(model_access, "_now", return_value=1002.0):
+            self.client.get(reverse("astrodash:dash_twins"))
+
+    def test_scoped_flow_writes_no_unsweepable_session_key(self) -> None:
+        self._run_scoped_flow()
+        self.assertEqual(_unsweepable_session_keys(self.client.session), [])
+
+    def test_teardown_then_leaves_nothing_of_the_flow_behind(self) -> None:
+        self._run_scoped_flow()
+        with gated_gate(), patch.object(model_access, "_now", return_value=1003.0):
+            self.client.post(reverse("astrodash:end_model_scope"))
+        session = self.client.session
+        self.assertEqual(
+            [k for k in session.keys() if not k.startswith("_")],
+            [],
+        )
+
+    def test_the_guard_would_flag_a_key_outside_the_swept_namespaces(self) -> None:
+        self.assertEqual(
+            _unsweepable_session_keys({"twins_embedding_cache": [1, 2, 3]}),
+            ["twins_embedding_cache"],
+        )
+
+    def test_the_guard_accepts_the_keys_teardown_actually_sweeps(self) -> None:
+        swept = {
+            model_access.SCOPE_MODEL_KEY: "dash",
+            model_access.SCOPE_DEADLINE_KEY: 1.0,
+            "selected_model_type": "dash",
+            "classify_results": {},
+            "_session_expiry": 60,
+        }
+        self.assertEqual(_unsweepable_session_keys(swept), [])

--- a/app/astrodash/tests/test_no_model_type_literals.py
+++ b/app/astrodash/tests/test_no_model_type_literals.py
@@ -81,9 +81,27 @@ GATE_FILES = (
 # numbers intact, so a real hit still reports where it is.
 TEMPLATE_COMMENT_PATTERNS = (
     re.compile(r"<!--.*?-->", re.DOTALL),
-    re.compile(r"\{#.*?#\}", re.DOTALL),
+    # Django's own lexer is ``{%.*?%}|{{.*?}}|{#.*?#}`` with no DOTALL, so a
+    # ``{# #}`` comment cannot span lines -- a multi-line one is rendered to the
+    # visitor verbatim. Stripping it here without that restriction would make
+    # the guard blind to a literal that actually reaches the page, so this
+    # pattern stays single-line for the same reason Django's is.
+    re.compile(r"\{#[^\n]*?#\}"),
     re.compile(r"\{%\s*comment\s*.*?%\}.*?\{%\s*endcomment\s*%\}", re.DOTALL),
 )
+
+# Every template the app renders. The multi-line-comment guard below scans all
+# of them, not just the gate files: the defect is a property of the syntax, so
+# it can appear in any template.
+TEMPLATE_ROOTS = (
+    "astrodash/templates",
+    "../users/templates",
+)
+
+# What an author meant as a Django comment. Matched WITH DOTALL on purpose --
+# the point is to find spans that look like comments to a human but are not
+# comments to Django.
+INTENDED_COMMENT_PATTERN = re.compile(r"\{#.*?#\}", re.DOTALL)
 
 # A conditional comparison of a value against a quoted built-in model id, in
 # either order (``x == 'dash'`` or ``'dash' == x``). The quote style is
@@ -227,6 +245,14 @@ class GuardPatternsTests(SimpleTestCase):
                 f"comment was not stripped: {comment}",
             )
 
+    def test_a_literal_inside_a_multiline_hash_comment_still_trips_the_guard(
+        self,
+    ) -> None:
+        """Django renders that span, so the literal reaches the page."""
+        not_really_a_comment = "{# see below\n   {% if model_type == 'dash' %} #}"
+        stripped = _strip_template_comments(not_really_a_comment)
+        self.assertTrue(COMPARISON_PATTERN.search(stripped))
+
     def test_a_live_template_literal_still_trips_the_guard(self) -> None:
         live = "{% if selected_model_type == 'dash' %}"
         self.assertTrue(COMPARISON_PATTERN.search(_strip_template_comments(live)))
@@ -241,6 +267,82 @@ class GuardPatternsTests(SimpleTestCase):
             if COMPARISON_PATTERN.search(line)
         ]
         self.assertEqual(hit, [4])
+
+
+def _multiline_django_comments(path: Path) -> List[Tuple[int, str]]:
+    """Find ``{# ... #}`` spans that cross a newline in one template.
+
+    Args:
+        path: The template to scan.
+
+    Returns:
+        A list of ``(lineno, first_line)`` tuples -- one per offending span.
+        Empty when the template is clean.
+    """
+    text = path.read_text(encoding="utf-8")
+    hits: List[Tuple[int, str]] = []
+    for match in INTENDED_COMMENT_PATTERN.finditer(text):
+        if "\n" in match.group(0):
+            lineno = text.count("\n", 0, match.start()) + 1
+            hits.append((lineno, match.group(0).splitlines()[0]))
+    return hits
+
+
+class NoMultilineTemplateCommentsTests(SimpleTestCase):
+    """A ``{# #}`` comment that spans lines is rendered, not hidden.
+
+    Django's lexer matches ``{#.*?#}`` without DOTALL, so a comment carrying a
+    newline is never tokenized as a comment: the visitor sees the text. It is
+    an easy mistake to make -- the syntax looks block-shaped -- and the failure
+    is silent in any template whose stray text lands outside a rendered block,
+    so it survives review until someone reads a page carefully.
+    """
+
+    def _templates(self) -> List[Path]:
+        found: List[Path] = []
+        for root in TEMPLATE_ROOTS:
+            found.extend(sorted((APP_ROOT / root).rglob("*.html")))
+        return found
+
+    def test_templates_have_no_multiline_django_comments(self) -> None:
+        offenders: List[str] = []
+        for path in self._templates():
+            for lineno, first_line in _multiline_django_comments(path):
+                rel = path.relative_to(APP_ROOT)
+                offenders.append(f"  {rel}:{lineno}: {first_line.strip()}")
+
+        self.assertFalse(
+            offenders,
+            "These '{#' comments span a newline, so Django renders them to the "
+            "visitor instead of stripping them. Use "
+            "{% comment %}...{% endcomment %} for a multi-line comment:\n"
+            + "\n".join(offenders),
+        )
+
+    def test_the_scan_finds_a_multiline_comment(self) -> None:
+        """The guard fires on the shape it exists to catch."""
+        import tempfile
+
+        with tempfile.NamedTemporaryFile("w", suffix=".html", delete=False) as handle:
+            handle.write("<p>a</p>\n{# first line\n   second line #}\n<p>b</p>\n")
+            offender = Path(handle.name)
+        try:
+            self.assertEqual(
+                _multiline_django_comments(offender), [(2, "{# first line")]
+            )
+        finally:
+            offender.unlink()
+
+    def test_the_scan_ignores_a_single_line_comment(self) -> None:
+        import tempfile
+
+        with tempfile.NamedTemporaryFile("w", suffix=".html", delete=False) as handle:
+            handle.write("<p>a</p>\n{# a real comment #}\n<p>b</p>\n")
+            clean = Path(handle.name)
+        try:
+            self.assertEqual(_multiline_django_comments(clean), [])
+        finally:
+            clean.unlink()
 
 
 def _is_gated(view) -> bool:

--- a/app/astrodash/ui_views.py
+++ b/app/astrodash/ui_views.py
@@ -27,6 +27,13 @@ from astrodash.infrastructure.ml.model_registry import (
     get_definition,
     listed_definitions,
 )
+from astrodash.core.model_access import (
+    EntryLinkRefused,
+    begin_scope,
+    credential_matches,
+    end_scope,
+    redeem_entry_link,
+)
 from astrodash.surfaces import resolve_surfaces
 from astrodash.services import (
     get_config,
@@ -254,6 +261,87 @@ def twins_search(request):
     except Exception as e:
         logger.exception("twins_search failed")
         return JsonResponse({'error': str(e)}, status=500)
+
+
+# Shown when a valid, unexpired link is presented with the wrong credential.
+# Generic by design: it confirms nothing about the link, the model, or how close
+# the attempt was.
+GATE_CREDENTIAL_ERROR = "That access code was not accepted. Please try again."
+
+
+def _render_gate_refusal(request, heading=None, message=None):
+    """Render the access-refusal page.
+
+    Args:
+        request: The current request.
+        heading: Optional heading override; the disclosure-minimal default is
+            used when omitted.
+        message: Optional message override, for a caller whose visitor already
+            knows which model they were using.
+
+    Returns:
+        HttpResponse: The refusal page, with status 403.
+    """
+    return render(
+        request,
+        "astrodash/model_gate_refused.html",
+        {"refusal_heading": heading, "refusal_message": message},
+        status=403,
+    )
+
+
+def model_gate(request, token):
+    """Redeem a model-scoped entry link and prompt for the shared credential.
+
+    The only way into a gated model. A GET renders the prompt; a POST checks the
+    submitted credential and, when it matches, establishes a session scoped to
+    the link's model. The link's deadline is re-checked on both, so a link that
+    lapses between the prompt and the submit is refused rather than honored.
+
+    Every refusal -- expired, tampered, malformed -- renders the same page with
+    the same wording, so the response discloses nothing about which models
+    exist. A link whose model has since been published redirects into the normal
+    public flow instead of refusing, so a reviewer is never locked out of a
+    model that is now public.
+
+    Args:
+        request: The current request.
+        token: The signed entry-link token from the path.
+
+    Returns:
+        HttpResponse: The credential prompt, a redirect into the classification
+        flow, or the refusal page.
+    """
+    try:
+        link = redeem_entry_link(token)
+    except EntryLinkRefused:
+        return _render_gate_refusal(request)
+
+    definition = get_definition(link.model_id)
+    if definition is None or not definition.requires_credential:
+        # The model has been published (or left the registry) since the link was
+        # minted: there is nothing to gate, so the link becomes an ordinary way
+        # in rather than a refusal.
+        end_scope(request.session)
+        if definition is None:
+            return HttpResponseRedirect(
+                reverse("astrodash:model_selection") + "?action=classify"
+            )
+        request.session["selected_model_type"] = link.model_id
+        return HttpResponseRedirect(reverse("astrodash:classify"))
+
+    context = {}
+    if request.method == "POST":
+        if credential_matches(request.POST.get("credential")):
+            begin_scope(request.session, link)
+            logger.info("Model gate: scope established for model_type=%s", link.model_id)
+            return HttpResponseRedirect(reverse("astrodash:classify"))
+        # A wrong credential on a still-valid link is retryable: redisplay the
+        # prompt with a generic error rather than burning the link.
+        logger.warning("Model gate: credential rejected")
+        context["credential_error"] = GATE_CREDENTIAL_ERROR
+
+    return render(request, "astrodash/model_gate.html", context)
 
 
 def model_selection(request):

--- a/app/astrodash/ui_views.py
+++ b/app/astrodash/ui_views.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from types import SimpleNamespace
 
 from astrodash.forms import ClassifyForm, BatchForm, ModelSelectionForm
-from astrodash.infrastructure.ml.model_registry import active_definitions, get_definition
+from astrodash.infrastructure.ml.model_registry import get_definition, listed_definitions
 from astrodash.services import (
     get_config,
     get_spectrum_processing_service,
@@ -181,9 +181,12 @@ def model_selection(request):
     Handles model selection page - allows choosing between dash/transformer or uploading a custom model.
     """
     action_type = request.GET.get('action', 'classify')  # 'classify' or 'batch'
-    # Active model definitions drive the selection cards (title, description,
-    # color, feature tags, icon, recommended badge, and order).
-    model_definitions = active_definitions()
+    # Listed model definitions drive the selection cards (title, description,
+    # color, feature tags, icon, recommended badge, and order). An unlisted
+    # model renders no card here, for the classify action and the batch action
+    # alike; the selection form's choices are drawn from the same listing, so
+    # a POST naming an unlisted model is refused rather than silently accepted.
+    model_definitions = listed_definitions()
     form = ModelSelectionForm(request.POST or None, request.FILES or None)
 
     # Populate existing user model options (must be done before is_valid() on POST too)

--- a/app/astrodash/ui_views.py
+++ b/app/astrodash/ui_views.py
@@ -1,6 +1,12 @@
 from django.shortcuts import render
 from django.contrib import messages
-from django.http import HttpResponseRedirect, FileResponse, Http404, JsonResponse
+from django.http import (
+    HttpResponseRedirect,
+    HttpResponseForbidden,
+    FileResponse,
+    Http404,
+    JsonResponse,
+)
 from django.views.decorators.clickjacking import xframe_options_sameorigin
 from django.urls import reverse
 from pathlib import Path
@@ -16,9 +22,12 @@ from astrodash.forms import (
 )
 from astrodash.infrastructure.ml.model_registry import (
     REDSHIFT_INPUT_REQUIRED,
+    SURFACE_CLASSIFICATION,
+    SURFACE_DASH_TWINS,
     get_definition,
     listed_definitions,
 )
+from astrodash.surfaces import resolve_surfaces
 from astrodash.services import (
     get_config,
     get_spectrum_processing_service,
@@ -127,12 +136,61 @@ def team_members(request):
     )
 
 
+# A model the registry cannot resolve -- a user-uploaded model -- offers the
+# classification surface alone (KTD10). It never renders zero tabs.
+FALLBACK_SURFACE_IDS = (SURFACE_CLASSIFICATION,)
+
+SURFACE_NOT_OFFERED_MESSAGE = "This result surface is not offered for this model."
+
+
+def _declared_surfaces(model_type):
+    """Resolve the result surfaces a model declares, in declared order.
+
+    Args:
+        model_type: A model id as held in the session -- the *selected* model
+            for a surface the visitor merely browses, the *classified* model
+            for a surface reading a classification artifact (KTD5). May be
+            ``None`` or a value the registry cannot resolve.
+
+    Returns:
+        tuple: The declared :class:`~astrodash.surfaces.Surface` entries, the
+        first of which is the default tab.
+    """
+    definition = get_definition(model_type) if model_type else None
+    surface_ids = (
+        definition.surfaces if definition is not None else FALLBACK_SURFACE_IDS
+    )
+    return resolve_surfaces(surface_ids)
+
+
+def _offers_route(model_type, route_name):
+    """Whether a model's declared surfaces own the given supporting route.
+
+    Args:
+        model_type: The model id that authorizes the route (see
+            :func:`_declared_surfaces` for which one that is).
+        route_name: The route's name in the ``astrodash`` URL namespace.
+
+    Returns:
+        bool: True when some declared surface lists the route as its own.
+    """
+    return any(
+        route_name in surface.routes for surface in _declared_surfaces(model_type)
+    )
+
+
 @xframe_options_sameorigin
 def dash_twins(request):
     """
     Renders the DASH Twins Explorer (embedding visualization).
     UI is in astrodash/explorer/dash_twins.html; data is loaded via dash_twins_data.
+
+    Authorized from the *selected* model per KTD5: the page shows a
+    model-agnostic global payload and reads no classification artifact, so it
+    stays browsable before any classification has run, exactly as today.
     """
+    if not _offers_route(request.session.get("selected_model_type"), "dash_twins"):
+        return HttpResponseForbidden(SURFACE_NOT_OFFERED_MESSAGE)
     return render(request, "astrodash/explorer/dash_twins.html")
 
 
@@ -140,7 +198,12 @@ def dash_twins_data(request):
     """
     Serves the DASH Twins payload JSON from {data_dir}/explorer (same as models, templates).
     Generate with extract_payload.py --build-artifacts (optionally --out-dir to data_dir/explorer).
+
+    Authorized from the *selected* model, for the same reason as the page it
+    feeds: the payload is global and carries nothing from a classification.
     """
+    if not _offers_route(request.session.get("selected_model_type"), "dash_twins_data"):
+        return JsonResponse({"error": SURFACE_NOT_OFFERED_MESSAGE}, status=403)
     path = Path(get_config().data_dir) / "explorer" / "dash_twins_payload.json"
     if not path.is_file():
         raise Http404("DASH Twins data not found. Run extract_payload.py --build-artifacts "
@@ -157,7 +220,13 @@ def twins_search(request):
     POST or GET: run twins search using the DASH embedding stored in session
     (set after classifying a spectrum with DASH). Returns JSON with query_umap,
     query_pca, twin_indices, twin_similarities, and optionally user_spectrum.
+
+    Authorized from the *classified* model per KTD5: this is the one twins
+    route that consumes a classification artifact (the stashed embedding), so
+    the model that produced that artifact decides whether it may be searched.
     """
+    if not _offers_route(request.session.get('classify_model_type'), 'twins_search'):
+        return JsonResponse({'error': SURFACE_NOT_OFFERED_MESSAGE}, status=403)
     import numpy as np
     embedding = request.session.get('classify_dash_embedding')
     if not embedding or not isinstance(embedding, list) or len(embedding) != 1024:
@@ -458,11 +527,17 @@ def classify(request):
             selected_model_display = (um.name or "").strip() or selected_model_id
         except Exception:
             selected_model_display = "User uploaded model"
+    # Result surfaces (the tab strip and its panes) come from the *selected*
+    # model's declared list per KTD5, so a fresh page load already shows every
+    # tab the chosen model offers, before any classification has run.
+    result_surfaces = _declared_surfaces(selected_model_type)
     context = {
         'form': form,
         'selected_model_type': selected_model_type,
         'selected_model_id': selected_model_id,
         'selected_model_display': selected_model_display,
+        'result_surfaces': result_surfaces,
+        'result_surface_ids': tuple(surface.id for surface in result_surfaces),
         # Whether the model that will actually run takes a redshift as an input;
         # a model that declines it renders neither redshift control.
         'show_redshift_controls': takes_redshift_input(selected_model_type),
@@ -670,8 +745,10 @@ def classify(request):
                 _annotate_best_match_template_variant_counts(formatted_results, show_templates_section)
 
                 # Store the embedding in session for "Find Twins" only when the
-                # model supports twins and the embedding is present.
-                if (classified_def is not None and classified_def.supports_twins
+                # classified model declares the twins surface (the declared
+                # list is the sole authority, R31) and the embedding is present.
+                if (classified_def is not None
+                        and SURFACE_DASH_TWINS in classified_def.surfaces
                         and isinstance(classification.results.get('embedding'), list)
                         and len(classification.results['embedding']) == 1024):
                     request.session['classify_dash_embedding'] = classification.results['embedding']

--- a/app/astrodash/ui_views.py
+++ b/app/astrodash/ui_views.py
@@ -28,6 +28,7 @@ from astrodash.infrastructure.ml.model_registry import (
 )
 from astrodash.core.model_access import (
     EntryLinkRefused,
+    GateNotConfigured,
     begin_scope,
     clear_selection,
     credential_matches,
@@ -254,6 +255,14 @@ def model_gate(request, token):
         link = redeem_entry_link(token)
     except EntryLinkRefused:
         return render_refusal(request)
+    except GateNotConfigured:
+        # The route exists in every deployment, gated model or not, so a visitor
+        # can reach it while the gate is unconfigured -- which is the shipped
+        # default, since the roster carries no gated model and the startup check
+        # therefore never runs. Fail closed onto the refusal page rather than a
+        # framework error page: this may be the first thing a reviewer sees.
+        logger.error("Model gate: link presented while the gate is unconfigured")
+        return render_refusal(request)
 
     definition = get_definition(link.model_id)
     if definition is None or not definition.requires_credential:
@@ -270,7 +279,12 @@ def model_gate(request, token):
 
     context = {}
     if request.method == "POST":
-        if credential_matches(request.POST.get("credential")):
+        try:
+            accepted = credential_matches(request.POST.get("credential"))
+        except GateNotConfigured:
+            logger.error("Model gate: credential submitted while the gate is unconfigured")
+            return render_refusal(request)
+        if accepted:
             begin_scope(request.session, link)
             logger.info("Model gate: scope established for model_type=%s", link.model_id)
             return HttpResponseRedirect(reverse("astrodash:classify"))

--- a/app/astrodash/ui_views.py
+++ b/app/astrodash/ui_views.py
@@ -7,6 +7,7 @@ from django.http import (
     JsonResponse,
 )
 from django.views.decorators.clickjacking import xframe_options_sameorigin
+from django.views.decorators.http import require_POST
 from django.urls import reverse
 from pathlib import Path
 from types import SimpleNamespace
@@ -33,6 +34,8 @@ from astrodash.core.model_access import (
     live_scope_model_id,
     model_access_required,
     redeem_entry_link,
+    revalidate_session_model,
+    scoped_flow_refusal,
 )
 from astrodash.surfaces import declared_surfaces
 from astrodash.services import (
@@ -298,10 +301,40 @@ def model_gate(request, token):
     return render(request, "astrodash/model_gate.html", context)
 
 
+@require_POST
+def end_model_scope(request):
+    """End a model-scoped session explicitly, discarding everything it produced.
+
+    A POST, because it changes server state; idempotent, so an unscoped visitor
+    (or a second click) simply lands back on the public picker. Navigating away
+    is deliberately not treated as an implicit end -- only this is.
+
+    Args:
+        request: The current request.
+
+    Returns:
+        HttpResponse: A redirect to the public model-selection page.
+    """
+    was_scoped = live_scope_model_id(request.session) is not None
+    end_scope(request.session)
+    if was_scoped:
+        messages.success(request, "Session ended. Choose a model to continue.")
+    return HttpResponseRedirect(
+        reverse('astrodash:model_selection') + '?action=classify'
+    )
+
+
 def model_selection(request):
     """
     Handles model selection page - allows choosing between dash/transformer or uploading a custom model.
     """
+    # A scoped session picks nothing: it is locked to one model, and its way out
+    # is the explicit end action, not this page. Refused before the POST handler
+    # so a hand-crafted selection cannot move a scope onto another model.
+    refusal = scoped_flow_refusal(request)
+    if refusal is not None:
+        return refusal
+
     action_type = request.GET.get('action', 'classify')  # 'classify' or 'batch'
     # Listed model definitions drive the selection cards (title, description,
     # color, feature tags, icon, recommended badge, and order). An unlisted
@@ -538,6 +571,13 @@ def classify(request):
     """
     Handles spectrum classification via the UI.
     """
+    # A scope whose model has been published dissolves here, and a public
+    # session whose model stopped being selectable is returned to the picker
+    # (R35), before any of it reaches a classification.
+    stale = revalidate_session_model(request, action='classify')
+    if stale is not None:
+        return stale
+
     # The model that will actually run: the scope first, then the session's
     # selection (KTD10). Inside a scope the selection cannot influence which
     # model executes, so a stale user-model id is dropped with it.
@@ -923,6 +963,15 @@ def batch_process(request):
     Handles batch processing UI.
     Support for both ZIP file uploads and multiple individual file uploads.
     """
+    # A scoped session reaches classification only (R24), and a session whose
+    # model stopped being selectable is returned to the picker (R35).
+    refusal = scoped_flow_refusal(request, action='batch')
+    if refusal is not None:
+        return refusal
+    stale = revalidate_session_model(request, action='batch')
+    if stale is not None:
+        return stale
+
     # Get model selection from session (set by model_selection view)
     selected_model_type = request.session.get('selected_model_type')
     selected_model_id = request.session.get('selected_model_id', None)

--- a/app/astrodash/ui_views.py
+++ b/app/astrodash/ui_views.py
@@ -6,8 +6,19 @@ from django.urls import reverse
 from pathlib import Path
 from types import SimpleNamespace
 
-from astrodash.forms import ClassifyForm, BatchForm, ModelSelectionForm
-from astrodash.infrastructure.ml.model_registry import get_definition, listed_definitions
+from astrodash.forms import (
+    ClassifyForm,
+    BatchForm,
+    ModelSelectionForm,
+    REDSHIFT_REQUIRED_MESSAGE,
+    redshift_input_policy,
+    takes_redshift_input,
+)
+from astrodash.infrastructure.ml.model_registry import (
+    REDSHIFT_INPUT_REQUIRED,
+    get_definition,
+    listed_definitions,
+)
 from astrodash.services import (
     get_config,
     get_spectrum_processing_service,
@@ -452,6 +463,9 @@ def classify(request):
         'selected_model_type': selected_model_type,
         'selected_model_id': selected_model_id,
         'selected_model_display': selected_model_display,
+        # Whether the model that will actually run takes a redshift as an input;
+        # a model that declines it renders neither redshift control.
+        'show_redshift_controls': takes_redshift_input(selected_model_type),
         'persisted_file_name': (request.session.get('classify_uploaded_file') or {}).get('name'),
     }
 
@@ -775,7 +789,12 @@ def batch_process(request):
         return HttpResponseRedirect(reverse('astrodash:model_selection') + '?action=batch')
 
     form = BatchForm(request.POST or None, request.FILES or None)
-    context = {'form': form}
+    context = {
+        'form': form,
+        # Same policy the classification flow renders on: a model that takes no
+        # redshift shows neither redshift control here either.
+        'show_redshift_controls': takes_redshift_input(selected_model_type),
+    }
 
     if request.method == 'POST':
         logger.info(
@@ -789,12 +808,12 @@ def batch_process(request):
         files = request.FILES.getlist('files')
 
         if form.is_valid():
-            # Models whose definition requires a redshift (Transformer today)
-            # need one when known_z is not set.
-            batch_def = get_definition(selected_model_type)
-            if (batch_def is not None and batch_def.requires_redshift
+            # This gate is the batch flow's own, separate from the classify
+            # form's, but reads the same declared policy: only a model whose
+            # definition requires a redshift is refused for missing one.
+            if (redshift_input_policy(selected_model_type) == REDSHIFT_INPUT_REQUIRED
                     and form.cleaned_data.get('redshift') is None):
-                form.add_error('redshift', "Redshift is required for Transformer model.")
+                form.add_error('redshift', REDSHIFT_REQUIRED_MESSAGE)
             else:
                 try:
                     model_type = selected_model_type

--- a/app/astrodash/ui_views.py
+++ b/app/astrodash/ui_views.py
@@ -2,7 +2,6 @@ from django.shortcuts import render
 from django.contrib import messages
 from django.http import (
     HttpResponseRedirect,
-    HttpResponseForbidden,
     FileResponse,
     Http404,
     JsonResponse,
@@ -22,7 +21,6 @@ from astrodash.forms import (
 )
 from astrodash.infrastructure.ml.model_registry import (
     REDSHIFT_INPUT_REQUIRED,
-    SURFACE_CLASSIFICATION,
     SURFACE_DASH_TWINS,
     get_definition,
     listed_definitions,
@@ -32,9 +30,11 @@ from astrodash.core.model_access import (
     begin_scope,
     credential_matches,
     end_scope,
+    live_scope_model_id,
+    model_access_required,
     redeem_entry_link,
 )
-from astrodash.surfaces import resolve_surfaces
+from astrodash.surfaces import declared_surfaces
 from astrodash.services import (
     get_config,
     get_spectrum_processing_service,
@@ -143,50 +143,8 @@ def team_members(request):
     )
 
 
-# A model the registry cannot resolve -- a user-uploaded model -- offers the
-# classification surface alone (KTD10). It never renders zero tabs.
-FALLBACK_SURFACE_IDS = (SURFACE_CLASSIFICATION,)
-
-SURFACE_NOT_OFFERED_MESSAGE = "This result surface is not offered for this model."
-
-
-def _declared_surfaces(model_type):
-    """Resolve the result surfaces a model declares, in declared order.
-
-    Args:
-        model_type: A model id as held in the session -- the *selected* model
-            for a surface the visitor merely browses, the *classified* model
-            for a surface reading a classification artifact (KTD5). May be
-            ``None`` or a value the registry cannot resolve.
-
-    Returns:
-        tuple: The declared :class:`~astrodash.surfaces.Surface` entries, the
-        first of which is the default tab.
-    """
-    definition = get_definition(model_type) if model_type else None
-    surface_ids = (
-        definition.surfaces if definition is not None else FALLBACK_SURFACE_IDS
-    )
-    return resolve_surfaces(surface_ids)
-
-
-def _offers_route(model_type, route_name):
-    """Whether a model's declared surfaces own the given supporting route.
-
-    Args:
-        model_type: The model id that authorizes the route (see
-            :func:`_declared_surfaces` for which one that is).
-        route_name: The route's name in the ``astrodash`` URL namespace.
-
-    Returns:
-        bool: True when some declared surface lists the route as its own.
-    """
-    return any(
-        route_name in surface.routes for surface in _declared_surfaces(model_type)
-    )
-
-
 @xframe_options_sameorigin
+@model_access_required("dash_twins")
 def dash_twins(request):
     """
     Renders the DASH Twins Explorer (embedding visualization).
@@ -196,11 +154,10 @@ def dash_twins(request):
     model-agnostic global payload and reads no classification artifact, so it
     stays browsable before any classification has run, exactly as today.
     """
-    if not _offers_route(request.session.get("selected_model_type"), "dash_twins"):
-        return HttpResponseForbidden(SURFACE_NOT_OFFERED_MESSAGE)
     return render(request, "astrodash/explorer/dash_twins.html")
 
 
+@model_access_required("dash_twins_data", as_json=True)
 def dash_twins_data(request):
     """
     Serves the DASH Twins payload JSON from {data_dir}/explorer (same as models, templates).
@@ -209,8 +166,6 @@ def dash_twins_data(request):
     Authorized from the *selected* model, for the same reason as the page it
     feeds: the payload is global and carries nothing from a classification.
     """
-    if not _offers_route(request.session.get("selected_model_type"), "dash_twins_data"):
-        return JsonResponse({"error": SURFACE_NOT_OFFERED_MESSAGE}, status=403)
     path = Path(get_config().data_dir) / "explorer" / "dash_twins_payload.json"
     if not path.is_file():
         raise Http404("DASH Twins data not found. Run extract_payload.py --build-artifacts "
@@ -222,6 +177,7 @@ def dash_twins_data(request):
     )
 
 
+@model_access_required("twins_search", from_classified=True, as_json=True)
 def twins_search(request):
     """
     POST or GET: run twins search using the DASH embedding stored in session
@@ -232,8 +188,6 @@ def twins_search(request):
     route that consumes a classification artifact (the stashed embedding), so
     the model that produced that artifact decides whether it may be searched.
     """
-    if not _offers_route(request.session.get('classify_model_type'), 'twins_search'):
-        return JsonResponse({'error': SURFACE_NOT_OFFERED_MESSAGE}, status=403)
     import numpy as np
     embedding = request.session.get('classify_dash_embedding')
     if not embedding or not isinstance(embedding, list) or len(embedding) != 1024:
@@ -552,14 +506,48 @@ def model_selection(request):
     return render(request, 'astrodash/model_selection.html', context)
 
 
+def _build_classify_form(effective_model, data=None, files=None, initial=None):
+    """Build the classification form bound to the model that will actually run.
+
+    The effective model drives both the form's choices and its redshift policy
+    (KTD10). Without it the two disagree in a scoped session: a gated model is
+    unlisted, so its id is in no listed choice set, and the submission would
+    fail validation before the view ever consulted the scope.
+
+    Args:
+        effective_model: The model that will run -- the scoped model when a
+            scope is live, otherwise the session's selection.
+        data: Bound POST data, or ``None`` for an unbound form.
+        files: Bound files, or ``None``.
+        initial: Initial field values, or ``None``.
+
+    Returns:
+        ClassifyForm: The form, with the user-uploaded entry hidden from the
+        dropdown unless it is what was selected (it travels as a hidden input).
+    """
+    form = ClassifyForm(data, files, initial=initial, effective_model=effective_model)
+    if effective_model != 'user_uploaded':
+        form.fields['model'].choices = [
+            c for c in form.fields['model'].choices if c[0] != 'user_uploaded'
+        ]
+    return form
+
+
+@model_access_required()
 def classify(request):
     """
     Handles spectrum classification via the UI.
     """
-    # Get model selection from session (set by model_selection view)
+    # The model that will actually run: the scope first, then the session's
+    # selection (KTD10). Inside a scope the selection cannot influence which
+    # model executes, so a stale user-model id is dropped with it.
+    scoped_model_type = live_scope_model_id(request.session)
     selected_model_type = request.session.get('selected_model_type')
     selected_model_id = request.session.get('selected_model_id') or None
     if selected_model_id == '':
+        selected_model_id = None
+    if scoped_model_type is not None:
+        selected_model_type = scoped_model_type
         selected_model_id = None
 
     # If no model selected, redirect to model selection
@@ -596,16 +584,7 @@ def classify(request):
                 # If cached file restore fails, continue with original request files.
                 form_files = request.FILES or None
 
-    form = ClassifyForm(request.POST or None, form_files)
-    # Set the model from session (for validation and display)
-    form.fields['model'].initial = (
-        'user_uploaded' if selected_model_type == 'user_uploaded' else selected_model_type
-    )
-    # When showing the dropdown, only offer dash/transformer; user_uploaded is sent via hidden input
-    if selected_model_type != 'user_uploaded':
-        form.fields['model'].choices = [
-            c for c in form.fields['model'].choices if c[0] != 'user_uploaded'
-        ]
+    form = _build_classify_form(selected_model_type, request.POST or None, form_files)
     # Display label for "Model Used" when a user model is selected
     selected_model_display = None
     if selected_model_type == 'user_uploaded' and selected_model_id:
@@ -615,15 +594,25 @@ def classify(request):
             selected_model_display = (um.name or "").strip() or selected_model_id
         except Exception:
             selected_model_display = "User uploaded model"
+    # In a scoped session the model control is not a choice: it renders
+    # disabled, naming the one model the scope allows.
+    scoped_model_display = None
+    if scoped_model_type is not None:
+        scoped_definition = get_definition(scoped_model_type)
+        scoped_model_display = (
+            scoped_definition.title if scoped_definition else scoped_model_type
+        )
     # Result surfaces (the tab strip and its panes) come from the *selected*
     # model's declared list per KTD5, so a fresh page load already shows every
     # tab the chosen model offers, before any classification has run.
-    result_surfaces = _declared_surfaces(selected_model_type)
+    result_surfaces = declared_surfaces(selected_model_type)
     context = {
         'form': form,
         'selected_model_type': selected_model_type,
         'selected_model_id': selected_model_id,
         'selected_model_display': selected_model_display,
+        'scoped_model_type': scoped_model_type,
+        'scoped_model_display': scoped_model_display,
         'result_surfaces': result_surfaces,
         'result_surface_ids': tuple(surface.id for surface in result_surfaces),
         # Whether the model that will actually run takes a redshift as an input;
@@ -709,15 +698,9 @@ def classify(request):
                 })
                 last_params = request.session.get('classify_last_params') or {}
                 if last_params:
-                    overlay_form = ClassifyForm(initial=last_params)
-                    overlay_form.fields['model'].initial = (
-                        'user_uploaded' if selected_model_type == 'user_uploaded' else selected_model_type
+                    context['form'] = _build_classify_form(
+                        selected_model_type, initial=last_params
                     )
-                    if selected_model_type != 'user_uploaded':
-                        overlay_form.fields['model'].choices = [
-                            c for c in overlay_form.fields['model'].choices if c[0] != 'user_uploaded'
-                        ]
-                    context['form'] = overlay_form
                 return render(request, 'astrodash/classify.html', context)
             # Fall through to normal render if no overlays or restore failed
 
@@ -916,17 +899,12 @@ def classify(request):
                     'persisted_file_name': (request.session.get('classify_uploaded_file') or {}).get('name'),
                 })
                 if source_changed:
-                    replacement_form = ClassifyForm(
-                        initial={'supernova_name': supernova_name} if supernova_name else None
+                    context['form'] = _build_classify_form(
+                        selected_model_type,
+                        initial=(
+                            {'supernova_name': supernova_name} if supernova_name else None
+                        ),
                     )
-                    replacement_form.fields['model'].initial = (
-                        'user_uploaded' if selected_model_type == 'user_uploaded' else selected_model_type
-                    )
-                    if selected_model_type != 'user_uploaded':
-                        replacement_form.fields['model'].choices = [
-                            c for c in replacement_form.fields['model'].choices if c[0] != 'user_uploaded'
-                        ]
-                    context['form'] = replacement_form
 
             except AppException as e:
                 messages.error(request, f"Processing Error: {e.message}")

--- a/app/astrodash/ui_views.py
+++ b/app/astrodash/ui_views.py
@@ -29,11 +29,13 @@ from astrodash.infrastructure.ml.model_registry import (
 from astrodash.core.model_access import (
     EntryLinkRefused,
     begin_scope,
+    clear_selection,
     credential_matches,
     end_scope,
     live_scope_model_id,
     model_access_required,
     redeem_entry_link,
+    render_refusal,
     revalidate_session_model,
     scoped_flow_refusal,
 )
@@ -226,27 +228,6 @@ def twins_search(request):
 GATE_CREDENTIAL_ERROR = "That access code was not accepted. Please try again."
 
 
-def _render_gate_refusal(request, heading=None, message=None):
-    """Render the access-refusal page.
-
-    Args:
-        request: The current request.
-        heading: Optional heading override; the disclosure-minimal default is
-            used when omitted.
-        message: Optional message override, for a caller whose visitor already
-            knows which model they were using.
-
-    Returns:
-        HttpResponse: The refusal page, with status 403.
-    """
-    return render(
-        request,
-        "astrodash/model_gate_refused.html",
-        {"refusal_heading": heading, "refusal_message": message},
-        status=403,
-    )
-
-
 def model_gate(request, token):
     """Redeem a model-scoped entry link and prompt for the shared credential.
 
@@ -272,7 +253,7 @@ def model_gate(request, token):
     try:
         link = redeem_entry_link(token)
     except EntryLinkRefused:
-        return _render_gate_refusal(request)
+        return render_refusal(request)
 
     definition = get_definition(link.model_id)
     if definition is None or not definition.requires_credential:
@@ -596,8 +577,7 @@ def classify(request):
 
     # User chose "Use uploaded model" but no id in session → redirect to re-pick
     if selected_model_type == 'user_uploaded' and not selected_model_id:
-        request.session.pop('selected_model_type', None)
-        request.session.pop('selected_model_id', None)
+        clear_selection(request.session)
         messages.warning(request, "Please select an uploaded model again.")
         return HttpResponseRedirect(reverse('astrodash:model_selection') + '?action=classify')
 
@@ -965,7 +945,7 @@ def batch_process(request):
     """
     # A scoped session reaches classification only (R24), and a session whose
     # model stopped being selectable is returned to the picker (R35).
-    refusal = scoped_flow_refusal(request, action='batch')
+    refusal = scoped_flow_refusal(request)
     if refusal is not None:
         return refusal
     stale = revalidate_session_model(request, action='batch')

--- a/app/astrodash/urls.py
+++ b/app/astrodash/urls.py
@@ -9,6 +9,10 @@ urlpatterns = [
     # UI Views
     path("", ui_views.landing_page, name="landing_page"),
     path("select-model/", ui_views.model_selection, name="model_selection"),
+    # The entry link for a gated model. This is the redeem side only: no route
+    # mints a link, because minting is an operator action (see the
+    # mint_model_link management command).
+    path("model-access/<str:token>/", ui_views.model_gate, name="model_gate"),
     path("classify/", ui_views.classify, name="classify"),
     path("batch/", ui_views.batch_process, name="batch_process_ui"),
     path("team/", ui_views.team_members, name="team_members"),

--- a/app/astrodash/urls.py
+++ b/app/astrodash/urls.py
@@ -9,6 +9,9 @@ urlpatterns = [
     # UI Views
     path("", ui_views.landing_page, name="landing_page"),
     path("select-model/", ui_views.model_selection, name="model_selection"),
+    # The explicit end of a model-scoped session. Declared before the entry-link
+    # route below, whose token pattern would otherwise swallow this path.
+    path("model-access/end/", ui_views.end_model_scope, name="end_model_scope"),
     # The entry link for a gated model. This is the redeem side only: no route
     # mints a link, because minting is an operator action (see the
     # mint_model_link management command).

--- a/app/astrodash/views.py
+++ b/app/astrodash/views.py
@@ -70,6 +70,14 @@ def _resolve_model_type(params: dict, model_id: str | None) -> str:
     A present ``model_id`` takes precedence and routes to the user-uploaded
     path without consulting the registry (mirroring the factory precedence).
 
+    A model that requires the shared credential is refused outright: the REST
+    API offers no way to present that credential, so a gated model is never
+    reachable here. The refusal is deliberately identical to the unknown-model
+    refusal, so the endpoint cannot be used to enumerate unreleased models.
+
+    Listing is not consulted: it is presentation only, so an unlisted model
+    that requires no credential stays resolvable by anyone who names it.
+
     Args:
         params: Parsed request params; ``modelType`` is read from here.
         model_id: The user-uploaded model id, if any. When truthy it wins.
@@ -80,8 +88,8 @@ def _resolve_model_type(params: dict, model_id: str | None) -> str:
 
     Raises:
         AppException: With HTTP 400 when, absent a ``model_id``, ``modelType``
-            is omitted/empty, names no registry definition, or names a retired
-            (inactive) definition.
+            is omitted/empty, names no registry definition, names a definition
+            requiring a credential, or names a retired (inactive) definition.
     """
     if model_id:
         return "user_uploaded"
@@ -92,6 +100,12 @@ def _resolve_model_type(params: dict, model_id: str | None) -> str:
 
     definition = get_definition(model_type)
     if definition is None:
+        raise AppException(
+            f"Unknown model type: {model_type}.", status_code=HTTP_400_BAD_REQUEST
+        )
+    # Checked before the status check so a gated model that is also retired
+    # still answers with the unknown-model refusal and discloses nothing.
+    if definition.requires_credential:
         raise AppException(
             f"Unknown model type: {model_type}.", status_code=HTTP_400_BAD_REQUEST
         )

--- a/app/astrodash_project/settings.py
+++ b/app/astrodash_project/settings.py
@@ -67,6 +67,10 @@ CSRF_TRUSTED_ORIGINS = ["http://localhost", "http://localhost:8000", "http://loc
 for hostname in HOSTNAMES:
     CSRF_TRUSTED_ORIGINS.append(f"""https://{hostname}""")
 CSRF_COOKIE_SECURE = True
+# The session cookie can now carry authorization -- a session scoped to a gated
+# model -- and not merely a model preference, so it is marked secure alongside
+# the CSRF cookie rather than being left to travel in plaintext.
+SESSION_COOKIE_SECURE = True
 
 # Application definition
 

--- a/docs/admin/gated-model-access.md
+++ b/docs/admin/gated-model-access.md
@@ -1,0 +1,110 @@
+# Serving a Gated Model
+
+A model definition can declare that running it requires a shared access code
+(`requires_credential=True`). Such a model is **gated**: it does not appear on
+the model-selection page or in any choice control, the REST API refuses it
+outright, and the only way to reach it is a *model-scoped entry link* that you
+mint and hand to whoever distributes it.
+
+This exists for one situation: a classifier that must be usable before it is
+public — typically by an anonymous peer reviewer, who cannot be asked to create
+an account. It is deliberately interim, and the identity-and-access work will
+retire it.
+
+## What you must configure
+
+A deployment whose registry contains a gated model **refuses to start** unless
+the first three values below are set. The check runs in the app-ready hook, so a
+misconfigured deployment fails in the init container with the missing names in
+its logs rather than serving the model without a prompt.
+
+| Value | Where | Purpose |
+|---|---|---|
+| `ASTRODASH_MODEL_GATE_CREDENTIAL` | sealed secret | The shared access code a visitor types. |
+| `ASTRODASH_MODEL_GATE_LINK_TTL_SECONDS` | configmap | How long a newly minted link is valid, in seconds. |
+| `SECRET_KEY` | sealed secret | Signs entry links. Must not be left at the committed `django-insecure-…` default — a key published in the repository would make links forgeable. |
+| `ASTRODASH_MODEL_GATE_LINK_BASE_URL` | configmap | The public base URL links are minted against, e.g. `https://astrodash-dev.scimma.org`. Needed only when minting. |
+
+These live in the chart in `../astrodash-k8s-gitops`. Sealed secrets are
+per-cluster, so DEV and PROD each need their own re-sealed values.
+
+An unset, empty, or whitespace-only value counts as unconfigured, as does a
+`SECRET_KEY` still carrying the committed prefix.
+
+## Minting a link
+
+Minting is operator-only: no route mints a link, so a link can only come from a
+shell on a running deployment.
+
+```bash
+# In the app container
+python manage.py mint_model_link <model-id>
+
+# Or with a one-off window, in seconds
+python manage.py mint_model_link <model-id> --ttl-seconds 1209600
+```
+
+The command prints one URL, and nothing else. It refuses a model that is unknown
+or not gated, and it never prints the access code.
+
+The deadline is stamped into the link when it is minted. Changing
+`ASTRODASH_MODEL_GATE_LINK_TTL_SECONDS` afterwards does not move the deadline of
+a link that already exists — in either direction. To shorten access that is
+already out there, rotate the access code (below).
+
+## What to hand over
+
+Two things, and it is worth sending them separately:
+
+1. **The link** printed by the command.
+2. **The access code** — the value of `ASTRODASH_MODEL_GATE_CREDENTIAL`.
+
+The recipient opens the link, is prompted for the code, and lands in a
+classification session locked to that one model. They can classify spectra and
+use whichever result tabs the model declares. They cannot reach the batch flow,
+the model picker, or any other model, and there is an explicit **End session**
+control on the page.
+
+A mistyped code is retryable while the link is still valid. An expired or
+tampered link is refused with a page that names no model and reveals nothing
+about which models exist.
+
+## The session ends when the link does
+
+The session carries the link's own deadline, so continuing to work does not
+extend it — activity is not a heartbeat. When the deadline passes, the next
+request is refused, and everything that session produced (results, plots, the
+twins embedding) is discarded with it.
+
+The visitor can also end the session themselves, which discards the same things
+immediately.
+
+## Rotating the access code
+
+One code covers every simultaneously gated model. Change the sealed secret and
+restart the pods; outstanding links then need the new code. There is no
+per-visitor code and no way to revoke a single link — if you need that, rotate
+and re-mint.
+
+## Publishing the model
+
+Publishing is a definition change, not an operator action:
+
+1. Clear `requires_credential` and set `listed=True` on the model's definition.
+2. Deploy.
+
+The card appears on the selection page and the model behaves like any other. A
+visitor who was inside a scoped session finds it dissolved into an ordinary
+selection of the same model on their next request, and an outstanding entry link
+now leads into the normal public flow rather than refusing — so nobody is locked
+out of a model that has just become public.
+
+Once no gated model remains in the roster, the gate configuration is no longer
+required for startup, though leaving the values in place is harmless.
+
+## One operational constraint
+
+The request profiler (Django Silk) is installed and its sample rate is
+environment-tunable. It can capture request bodies, which in this flow means the
+access code and uploaded spectra. Do not raise `SILKY_INTERCEPT_PERCENT` in an
+environment serving a gated model.

--- a/docs/admin/gated-model-access.md
+++ b/docs/admin/gated-model-access.md
@@ -49,8 +49,9 @@ or not gated, and it never prints the access code.
 
 The deadline is stamped into the link when it is minted. Changing
 `ASTRODASH_MODEL_GATE_LINK_TTL_SECONDS` afterwards does not move the deadline of
-a link that already exists — in either direction. To shorten access that is
-already out there, rotate the access code (below).
+a link that already exists — in either direction. Keep the window no longer than
+the access you actually intend to grant, because nothing shortens an outstanding
+link once it is minted.
 
 ## What to hand over
 
@@ -81,10 +82,15 @@ immediately.
 
 ## Rotating the access code
 
-One code covers every simultaneously gated model. Change the sealed secret and
-restart the pods; outstanding links then need the new code. There is no
-per-visitor code and no way to revoke a single link — if you need that, rotate
-and re-mint.
+One code covers every simultaneously gated model. Make it long and random — it
+is checked only for being set, so nothing else stops a short one from being
+guessed, and there is no attempt limit by design.
+
+Change the sealed secret and restart the pods. Rotation stops an outstanding
+link from being redeemed with the old code; it does **not** end a session that
+already redeemed one. Those sessions end at the deadline their link carried, or
+when the visitor ends them. There is no per-visitor code and no way to revoke a
+single link — if you need that, rotate, re-mint, and wait out the window.
 
 ## Publishing the model
 
@@ -102,9 +108,14 @@ out of a model that has just become public.
 Once no gated model remains in the roster, the gate configuration is no longer
 required for startup, though leaving the values in place is harmless.
 
-## One operational constraint
+## Two operational constraints
 
 The request profiler (Django Silk) is installed and its sample rate is
 environment-tunable. It can capture request bodies, which in this flow means the
 access code and uploaded spectra. Do not raise `SILKY_INTERCEPT_PERCENT` in an
 environment serving a gated model.
+
+The link carries its token in the URL path, so it lands in ingress and proxy
+access logs, in browser history, and in whatever the recipient forwards it
+through. Treat a link as one half of a credential pair: it is useless without
+the access code, which is why the two are sent separately.

--- a/docs/guides/contributing-classifiers.md
+++ b/docs/guides/contributing-classifiers.md
@@ -21,9 +21,42 @@ This section explains how to add a first-class model kind (e.g., like `dash` or 
 #### 1. Register the model in the model registry
 
 - Directory: `app/astrodash/infrastructure/ml/model_registry/`
-- Create `definitions/<your_model>.py` defining a `ModelDefinition`: its `id` is the `model_type`, plus its UI card fields (title, description, color, feature tags, icon, recommended), lifecycle `status`, `is_default`, the capability/requirement flags (`requires_redshift`, `preprocessing`, `supports_twins`, `supports_redshift_estimation`, `supports_template_overlays`, `supports_rlap`), and a reference to your classifier class (see step 2). Copy `definitions/dash.py` or `definitions/transformer.py` as a template.
+- Create `definitions/<your_model>.py` defining a `ModelDefinition`. Copy `definitions/dash.py` or `definitions/transformer.py` as a template. A definition declares four separable things:
+
+  1. **Identity and presentation.** `id` (which is the `model_type`), the UI card fields (title, description, color, feature tags, icon, recommended), and `preprocessing`.
+  2. **Public surface.** `status` (`active` or `retired`), `listed`, `is_default`, and `requires_credential`. These are independent questions — see "Public surface" below.
+  3. **Inputs.** `redshift_input`, one of `REDSHIFT_INPUT_REQUIRED`, `REDSHIFT_INPUT_OPTIONAL`, or `REDSHIFT_INPUT_NONE`. This says whether redshift is an *input*; whether your model *estimates* one is the separate `supports_redshift_estimation` flag.
+  4. **Results.** `surfaces`, the ordered list of result surfaces your model offers (see "Result surfaces" below), plus the content flags that gate sections *within* a surface: `supports_redshift_estimation`, `supports_template_overlays`, `supports_rlap`.
+
+  Plus a reference to your classifier class (see step 2).
+
 - Add your definition to the ordered `MODELS` roster in `model_registry/__init__.py`.
-- You do **not** edit `model_factory.py`. `ModelFactory.get_classifier` resolves the definition through the registry (`get_definition(model_type).classifier(config)`), so registering the definition is enough for the factory to build your classifier. The forms, the model-selection cards, and the behavioral gates likewise read from the definition. Exactly one active definition may be the default; the registry's import-time invariant check enforces this.
+- You do **not** edit `model_factory.py`. `ModelFactory.get_classifier` resolves the definition through the registry (`get_definition(model_type).classifier(config)`), so registering the definition is enough for the factory to build your classifier. The forms, the model-selection cards, the result tabs, and the behavioral gates likewise read from the definition. The registry's import-time invariant check enforces that exactly one active definition is the default, that the default is listed and ungated, and that a gated model is never listed.
+
+#### 1a. Public surface: listed, active, gated
+
+Three separate questions, each with its own field:
+
+| Question | Field | Effect |
+|---|---|---|
+| Is it offered for new use? | `status` | A `retired` model leaves the cards and choice lists but still resolves its label for stored results. |
+| Is it advertised? | `listed` | An unlisted model renders no selection card and appears in no choice control. Listing is presentation only, never protection: an unlisted, ungated model stays resolvable by anyone who names it, including through the REST API. |
+| Does reaching it need a credential? | `requires_credential` | A gated model is reachable only by redeeming a model-scoped entry link and presenting a shared access code. It is refused outright by the REST API, and a session scoped to it may enter the classification flow only. |
+
+`requires_credential=True` implies `listed=False`, and a deployment whose roster contains a gated model must configure the gate or refuse to start. Making a model public is clearing both flags — nothing else about the definition changes. See [Serving a gated model](../admin/gated-model-access.md) for the operator side.
+
+#### 1b. Result surfaces
+
+Result tabs are a declared list, not a flag per tab. Your definition names the surfaces it offers, in the order they render, and the first is the default tab:
+
+```python
+surfaces=(SURFACE_CLASSIFICATION,)                       # Classification only
+surfaces=(SURFACE_CLASSIFICATION, SURFACE_DASH_TWINS)    # both, in that order
+```
+
+Every model must declare `SURFACE_CLASSIFICATION`. The ids are opaque to the registry; `app/astrodash/surfaces.py` maps each one to its tab title, its pane markup, and the supporting routes it owns. Declaring an id the surface map does not know refuses startup rather than rendering a broken tab.
+
+Adding a *new* surface is one entry in `SURFACES` plus the id constant — no per-model conditional in `classify.html`. A guard test scans that template (and `batch.html`) for `model_type == '<id>'` comparisons and fails if one reappears, and a second guard walks every route the surface map declares and fails if one is missing the access gate.
 
 #### 2. Implement the classifier
 
@@ -45,12 +78,12 @@ This section explains how to add a first-class model kind (e.g., like `dash` or 
 #### 4. Template/redshift support (optional)
 
 - If your model uses templates (for RLAP or redshift estimation), add a handler under `app/astrodash/infrastructure/ml/templates/` and wire it in `app/astrodash/infrastructure/ml/templates/template_factory.py`.
-- If not supported, leave the capability flags off. The redshift-estimation, twins, template-overlay, and RLAP gates read the definition's `supports_*` flags (e.g. `supports_redshift_estimation`), so a model with those flags `False` is excluded automatically — there is no per-model `model_type == 'dash'` branch to update.
+- If not supported, leave the content flags off. The redshift-estimation, template-overlay, and RLAP gates read the definition's `supports_*` flags, so a model with those flags `False` is excluded automatically — there is no per-model `model_type == 'dash'` branch to update. Whether a *tab* appears is the separate `surfaces` list.
 
 #### 5. API validation and routing
 
-- No allowed-list to widen. The REST endpoints in `app/astrodash/views.py` (`process_spectrum` and `batch_process`) resolve `modelType` through the registry via `_resolve_model_type`: any **active** definition is accepted automatically, and an omitted, unknown, or retired `modelType` returns `400`. Registering your definition with an active `status` is all the API needs to route to it.
-- Extra-input requirements travel on the definition too. Set `requires_redshift=True` and the classify form and batch view enforce it from the flag; you do not add a bespoke validation branch.
+- No allowed-list to widen. The REST endpoints in `app/astrodash/views.py` (`process_spectrum` and `batch_process`) resolve `modelType` through the registry via `_resolve_model_type`: any **active** definition is accepted automatically, and an omitted, unknown, or retired `modelType` returns `400`. Registering your definition with an active `status` is all the API needs to route to it. Listing is not consulted, so an unlisted, ungated model is reachable here; a **gated** model is refused, with a message deliberately identical to the unknown-model refusal.
+- Extra-input requirements travel on the definition too. Set `redshift_input=REDSHIFT_INPUT_REQUIRED` and both the classify form and the batch view enforce it from that policy; you do not add a bespoke validation branch. `REDSHIFT_INPUT_NONE` goes further: neither the redshift field nor the Known Redshift checkbox renders, and a submission without one validates in both flows.
 
 #### 6. Configuration
 
@@ -69,11 +102,12 @@ This section explains how to add a first-class model kind (e.g., like `dash` or 
 
 ### Frontend Changes (Django Templates)
 
-The AstroDash frontend uses Django templates with Bootstrap, and the model-selection surface is now registry-driven — you do not hand-edit the template to add a card:
+The AstroDash frontend uses Django templates with Bootstrap, and the model surface is registry-driven — you do not hand-edit a template to add a card or a tab:
 
-1. The model-selection cards render from the registry's active definitions (title, description, color, feature tags, icon, recommended badge, order), so setting your definition's UI fields adds the card. The form choice lists are generated the same way.
-2. Redshift gating follows your `requires_redshift` flag; RLAP and template-overlay UI follow `supports_rlap` and `supports_template_overlays`. Set the flags rather than adding `'dash'` vs `'transformer'` branches in the template or form.
-3. Ensure the result display matches your outputs (e.g., a model with `supports_rlap=False` produces no RLAP values to show).
+1. The model-selection cards render from the registry's **listed** definitions (title, description, color, feature tags, icon, recommended badge, order), so setting your definition's UI fields adds the card. The form choice lists are generated from the same listing.
+2. The result tabs render from your `surfaces` list, in the declared order, with the first active.
+3. Redshift controls follow your `redshift_input` policy; RLAP and template-overlay UI follow `supports_rlap` and `supports_template_overlays`. Set the fields rather than adding `'dash'` vs `'transformer'` branches in the template or form — a guard test scans the templates for exactly that.
+4. Ensure the result display matches your outputs (e.g., a model with `supports_rlap=False` produces no RLAP values to show).
 
 ### Documentation Updates
 
@@ -90,11 +124,12 @@ The AstroDash frontend uses Django templates with Bootstrap, and the model-selec
   - Registry definition added (`definitions/<id>.py` + `MODELS` entry) and classifier implemented
   - Preprocessor and `prepare_for_model` updated
   - Settings and env variables added
-  - Capability/requirement flags set on the definition (API validation and gates derive from them)
+  - Public surface declared: `status`, `listed`, `requires_credential`
+  - `redshift_input` policy set, and content flags set (API validation and gates derive from them)
 
 - Frontend
   - Definition UI fields set (card renders from the registry)
-  - Capability/requirement flags set (gating derives from them)
+  - `surfaces` list declared in the order the tabs should render
   - Result view aligns with outputs
 
 - Docs & Tests

--- a/docs/plans/2026-08-11-001-feat-registry-driven-model-surface-plan.md
+++ b/docs/plans/2026-08-11-001-feat-registry-driven-model-surface-plan.md
@@ -1,0 +1,730 @@
+---
+title: Registry-Driven Model Surface - Plan
+type: feat
+date: 2026-08-11
+topic: registry-driven-model-surface
+deepened: 2026-08-11
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+product_contract_source: ce-brainstorm
+execution: code
+---
+
+# Registry-Driven Model Surface - Plan
+
+## Goal Capsule
+
+- Objective: let a model definition control its own public surface — whether it is listed on the model-selection page, whether reaching it requires a credential, whether redshift is an input, and which result surfaces it offers.
+- Product authority: this plan owns the generic registry capability only. Integrating any specific new classifier is not active scope.
+- Authority hierarchy: a requirement wins on product behavior; a Key Technical Decision wins on implementation mechanism within its cited requirements; a unit overrides neither. Acceptance examples and flows illustrate, never amend.
+- Execution profile: nine units, dependency-ordered. U1 and U2 are the registry foundation and unblock everything else. The gate (U6, U7, U9) is the riskiest cluster and lands after the registry and surface work is proven.
+- Stop conditions: stop and ask if implementation reveals that a requirement cannot hold without changing product behavior, or that the gate cannot be built without a second authentication system — KD10 bounds it to the smallest shape that works.
+- Tail ownership: the implementer runs the Verification Contract gates and satisfies the Definition of Done. This plan does not own commits, branches, or deployment.
+- Open blockers: none.
+
+**Product Contract preservation:** changed — R26 extended (gated models are also never the registry default), AE6 reworded (the twins guard reads the session's model rather than a model named in the request, which the twins routes do not carry), and R33–R35 added. All four came from plan-time flow analysis and were confirmed before writing.
+
+---
+
+## Product Contract
+
+### Summary
+
+Model definitions gain control over their own public surface. A model can be fully usable while unlisted on the selection page, reachable only through a model-scoped entry link that expires and asks for a shared credential, and landing the visitor in a classification form locked to that one model. Definitions also declare whether redshift is an input at all, and which result surfaces they offer.
+
+### Problem Frame
+
+A model's presence in the registry currently implies its full public exposure. One boolean, `is_active`, answers three unrelated questions at once: whether a card renders on the selection page (`app/astrodash/ui_views.py:186`), whether the model appears in form choice lists (`app/astrodash/forms.py:15`), and whether the REST API will accept it (`app/astrodash/views.py:98`). A model is either wholly public or wholly unavailable — there is no state in between, and no per-model visibility or access concept exists anywhere in the application.
+
+That becomes a problem when a classifier must be usable before it is public. A model whose describing paper is under peer review needs to work for an assigned reviewer while remaining un-browsable by ordinary users, and the reviewer is anonymous, so any access path that requires an account is unavailable.
+
+Two other per-model traits are similarly stuck. `requires_redshift` distinguishes only required from optional — both render the field — so a model that derives redshift from the spectrum rather than accepting it has no way to say so, and the redshift and Known Redshift controls render unconditionally (`app/astrodash/templates/astrodash/classify.html:91`, `:94`). Result surfaces are worse: `supports_twins` exists but is read in exactly one place (`app/astrodash/ui_views.py:657`), while the DASH Twins tab, its button, and its pane are gated by three hardcoded `selected_model_type == 'dash'` conditionals in the same template (`:30`, `:114`, `:273`) that the literal-guard test cannot see, because it scans four Python files and no templates (`app/astrodash/tests/test_no_model_type_literals.py:37-42`).
+
+### Key Decisions
+
+- KD1. Split listing from usability. Whether a model appears in the picker becomes a property distinct from its lifecycle status and from whether it can run, because requirement R1 is precisely "invisible but working." Governs R1, R2, R3, R4, R26, R27.
+- KD2. Gate on the model, not on the page. The credential requirement is a property of the model that every surface consults, rather than a check added page by page, so a surface added later cannot silently omit it. Governs R9.
+- KD3. Model-scoped entry link carrying an expiry, plus a shared credential (session-settled: user-approved — chosen over a bare `?model=` query parameter, a signed link used as the sole credential, and ingress basic auth: it keeps the credential convention journal editors already use while adding expiry and preventing enumeration of unlisted models). Governs R5, R6, R7, R8, R10, R28.
+- KD4. Result surfaces are a declared, ordered list against a surface registry, not one boolean per tab (session-settled: user-approved — chosen over adding a boolean per surface: a third surface is already anticipated, and booleans require editing per-model conditionals in the template each time). Governs R16, R17, R18, R19, R20, R30, R31.
+- KD5. Redshift input policy is a three-way property, kept separate from whether a model estimates redshift. A model can decline redshift as an input and still produce one as an output. Governs R13, R14, R15.
+- KD6. This plan owns the generic capability only; integrating any specific classifier is separate work (session-settled: user-directed — chosen over one plan covering capability and classifier integration together, or driving from the integration and generalizing afterward: the capability is buildable and verifiable against DASH, Transformer, and a test-only gated fixture, and stays publishable without reference to any unreleased model). Governs R32.
+- KD7. Confidentiality for an unreleased classifier comes from where its commits live, not from loading it at runtime (session-settled: user-directed — chosen over moving model definitions to off-repo runtime configuration: it keeps the registry code-native and removes a data-driven registry from this plan entirely).
+- KD8. A gated session reaches classification only (session-settled: user-approved — chosen over admitting batch, or declaring reachable flows per model: it keeps the gated surface as small as the reviewing use case requires). Governs R24.
+- KD9. The REST API refuses gated models outright rather than accepting a credential (session-settled: user-approved — chosen over credentialed API access or deferring to the identity work: opening that path later costs less than withdrawing it once callers depend on it). Governs R25.
+- KD10. The shared-credential gate is interim, not a permanent product primitive. It exists because no identity layer is applied to AstroDash views today, and the identity-and-access work retires it when that work lands and takes over pre-publication access. Build it to the smallest shape that satisfies the requirements rather than as a durable second authentication system.
+
+The structural change KD1 makes, from one property answering three questions to three independent ones:
+
+```mermaid
+flowchart TB
+  subgraph after["Proposed"]
+    L[listed] --> L1[Card on selection page]
+    S2[status] --> S3[Offered for new use]
+    G[access policy] --> G1[Credential required to run]
+  end
+  subgraph before["Today"]
+    A[is_active] --> A1[Card on selection page]
+    A --> A2[Present in form choices]
+    A --> A3[Accepted by the REST API]
+  end
+```
+
+### Actors
+
+- A1. Anonymous reviewer — evaluates a model for a peer-reviewed submission. Reaches the model through a link forwarded to them, has no account, and must not be required to create one.
+- A2. Journal editor — receives the entry link and credential from the authors and forwards them to A1.
+- A3. Public user — an astronomer using AstroDash normally. Must never encounter an unlisted model in any listing, choice control, or result surface.
+- A4. Operator — configures listing, credential, and expiry for a deployment, and performs the change that makes a model public.
+
+### Requirements
+
+**Listing and visibility**
+
+- R1. A model definition declares whether it is listed, independently of its lifecycle status.
+- R2. An unlisted model renders no card on the model-selection page, for the classify action and the batch action alike.
+- R3. An unlisted model appears in no model choice control reachable by A3.
+- R4. Making a model public clears its listing declaration and, when the model was gated, its credential declaration; no other change to its definition is required.
+- R26. A gated model is also unlisted, and the active default is always listed and ungated, enforced as a registry invariant alongside the existing exactly-one-active-default check.
+- R27. Listing is a presentation property and never an access control; an unlisted model that declares no credential requirement stays reachable by anyone who names it, including through the REST API.
+
+**Reaching a gated model**
+
+- R5. A model definition declares whether running it requires a shared credential.
+- R6. A gated model is reachable only through a model-scoped entry link that carries an expiry.
+- R7. Presenting a valid, unexpired entry link prompts for the shared credential.
+- R8. A correct credential establishes a session scoped to that one model; an expired link or an incorrect credential grants no access and discloses nothing about which models exist.
+- R9. The credential requirement applies to every user-facing surface that can run the model, covering the classification form and each declared result surface with its supporting routes.
+- R10. The credential and the expiry window are deployment configuration, never values committed to the repository.
+- R28. A model-scoped session expires no later than the entry link that established it, so a lapsed link ends access already in progress as well as new access.
+- R34. A gated model whose credential, expiry window, or signing key is missing, empty, or left at a committed default fails closed, and the deployment refuses to start rather than serving that model ungated.
+
+**Model choice in the form**
+
+- R11. In a session scoped to one model, the model control renders disabled and displays that model's name.
+- R12. Within the scoped model's flow, a request cannot be altered to run a different model.
+- R29. A scoped session can be ended explicitly, returning the visitor to the public selection page with the scope cleared.
+
+**Redshift as an input**
+
+- R13. A model definition declares redshift as a required input, an optional input, or not an input.
+- R14. When a model does not take redshift as an input, the form renders neither the redshift field nor the Known Redshift checkbox, and a submission omitting redshift validates in the classification flow and the batch flow alike.
+- R15. Whether a model accepts redshift as an input is independent of whether it estimates redshift.
+
+**Result surfaces**
+
+- R16. A model definition declares an ordered list of the result surfaces it offers.
+- R17. Only declared surfaces render, in the declared order, with the first as the default.
+- R18. DASH declares Classification and DASH Twins; Transformer declares Classification only.
+- R19. A surface's supporting routes reject a request naming a model that does not declare that surface.
+- R20. Adding a surface requires registering it once, with no per-model conditional added to the classification template.
+- R30. A result surface is a tab in the classification result view with its own supporting routes.
+- R31. The declared surface list is the sole authority for the DASH Twins surface: the separate per-model twins flag is retired, and the twins embedding is stored only when the classified model declares that surface.
+
+**Compatibility and guardrails**
+
+- R21. For A3, DASH and Transformer behave exactly as they do today across selection, form, validation, and result surfaces.
+- R22. The literal-guard test covers templates, so a per-model conditional reintroduced in a template fails the suite.
+- R23. User-uploaded models continue to classify as they do today.
+- R32. The gating requirements are verified against a test-only gated model definition, constructed in the test suite and absent from the shipped roster.
+
+**Gated session boundaries**
+
+- R24. A session scoped to a gated model may enter the classification flow only, and never the batch flow.
+- R25. The REST API rejects any request naming a gated model, whether or not API writes are enabled.
+- R33. Ending or expiring a scope also discards the session-held classification artifacts that scope produced, so no result, embedding, or cached output from a gated model remains reachable once the scope is gone.
+- R35. A session whose model stops being selectable — because the model became gated, unlisted, or retired — is revalidated on entry to the classification and batch flows and returned to the selection page; a scope whose model has been published dissolves on its next request.
+
+### Key Flows
+
+- F1. Reviewer reaches a gated model
+  - **Trigger:** A1 opens the entry link A2 forwarded to them.
+  - **Actors:** A1, A2
+  - **Steps:** The link resolves to one model and is checked against its expiry; A1 is prompted for the shared credential; an incorrect credential on a still-valid link redisplays the prompt with a generic error and permits another attempt; a correct credential scopes the session to that model for no longer than the link's remaining window; A1 lands on the classification form with the model control disabled and named, redshift rendered per the model's declared policy, and only the model's declared surfaces present.
+  - **Outcome:** A1 classifies spectra with that model and reaches no other model.
+  - **Covered by:** R5, R6, R7, R8, R9, R11, R13, R14, R17, R24, R28, R29
+
+- F2. Public user selects a model
+  - **Trigger:** A3 opens the model-selection page for the classify or batch action.
+  - **Actors:** A3
+  - **Steps:** Cards render for listed models only; A3 chooses one and proceeds into the existing flow unchanged.
+  - **Outcome:** A3 never sees, selects, or reaches an unlisted model.
+  - **Covered by:** R2, R3, R21
+
+- F3. A model becomes public
+  - **Trigger:** A4 changes the model's listing declaration and deploys.
+  - **Actors:** A4
+  - **Steps:** A4 clears both the listing and the credential declarations, which the registry invariant requires to move together; the model's card appears on the selection page and its entry in choice controls becomes reachable; any outstanding entry link stops granting access once its window lapses.
+  - **Outcome:** The model behaves like any other listed model.
+  - **Covered by:** R1, R4, R26, R28
+
+```mermaid
+flowchart TB
+  E[Entry link opened] --> X{Within expiry?}
+  X -->|no| D[Refused, discloses nothing]
+  X -->|yes| C[Prompt for credential]
+  C --> V{Credential correct?}
+  V -->|no| D
+  V -->|yes| Z[Session scoped to one model]
+  Z --> F[Classify form: control disabled, redshift per policy, declared surfaces only]
+```
+
+### Acceptance Examples
+
+- AE1. Unlisted model is absent from both pickers.
+  - **Covers R2, R3.**
+  - **Given** a model declared active and unlisted, **when** A3 opens the model-selection page for either the classify or the batch action, **then** no card for that model renders and no choice control offers it.
+
+- AE2. Expired link is refused without disclosure.
+  - **Covers R6, R8.**
+  - **Given** an entry link whose expiry has passed, **when** A1 opens it, **then** access is refused and the response reveals nothing about whether that model exists.
+
+- AE3. Scoped session cannot be moved to another model.
+  - **Covers R11, R12.**
+  - **Given** a session scoped to a gated model, **when** the request is altered to name a different model, **then** the classification still runs against the scoped model and the control still displays it.
+
+- AE4. A model that does not take redshift renders no redshift controls.
+  - **Covers R13, R14.**
+  - **Given** a model declaring redshift as not an input, **when** its classification form renders, **then** neither the redshift field nor the Known Redshift checkbox is present, and a submission without redshift validates.
+
+- AE5. Redshift input and redshift estimation stay independent.
+  - **Covers R15.**
+  - **Given** a model that declines redshift as an input and estimates redshift from the spectrum, **when** its form renders and a classification runs, **then** no redshift input appears and a redshift estimate is still produced.
+
+- AE6. An undeclared surface is unreachable, not merely hidden.
+  - **Covers R17, R19.**
+  - **Given** a session whose last classification ran Transformer, which declares Classification only, **when** a twins supporting route is requested directly, **then** the request is rejected rather than served.
+
+- AE7. Existing models are untouched.
+  - **Covers R18, R21.**
+  - **Given** DASH and Transformer as configured today, **when** A3 classifies with either, **then** selection, form fields, validation messages, and available surfaces match current behavior, with DASH offering Twins and Transformer not.
+
+- AE8. A scoped session cannot enter batch.
+  - **Covers R24.**
+  - **Given** a session scoped to a gated model, **when** the batch flow is requested, **then** it is refused rather than served with the scoped model.
+
+- AE9. The API refuses a gated model even when writes are enabled.
+  - **Covers R25.**
+  - **Given** a gated model and API writes enabled, **when** a request names that model, **then** it is rejected, and the rejection is indistinguishable from that for an unknown model.
+
+- AE10. A scoped session does not outlive the link that created it, however active it is.
+  - **Covers R28.**
+  - **Given** a session established from an entry link, **when** the link's deadline passes, **then** access stops — including for a visitor who has been classifying continuously the whole time, whose activity must not extend the deadline.
+
+- AE15. A stale selection cannot displace the scope.
+  - **Covers R12, R29.**
+  - **Given** a visitor whose session already holds a user-uploaded model selection, **when** they redeem an entry link and classify, **then** the scoped model runs and the prior selection no longer influences which model executes.
+
+- AE11. A mistyped credential on a valid link is retryable.
+  - **Covers R7, R8.**
+  - **Given** a valid, unexpired entry link, **when** an incorrect credential is submitted, **then** the prompt redisplays with a generic error and another attempt is permitted, while an expired link still refuses without disclosure.
+
+- AE12. Ending a scope discards what it produced.
+  - **Covers R29, R33.**
+  - **Given** a scoped session that has classified a spectrum and holds the resulting embedding, **when** the scope is ended explicitly or lapses, **then** a subsequent request to a twins supporting route is refused rather than served from the retained embedding.
+
+- AE13. An unconfigured gate refuses to start.
+  - **Covers R34.**
+  - **Given** a model declaring a credential requirement and a deployment with no credential configured, **when** the application starts, **then** startup fails with a message naming the missing configuration, rather than serving that model without a prompt.
+
+- AE14. A session pointing at a newly gated model is turned away.
+  - **Covers R35.**
+  - **Given** a public session that selected a model before a deploy that gated it, **when** the classification flow is entered, **then** the visitor is returned to the selection page rather than reaching the gate through the stale session.
+
+### Scope Boundaries
+
+- Integrating any specific new classifier — its definition, classifier implementation, preprocessing path, dependencies, or weights.
+- The Reconstruction result surface. This plan builds the mechanism that would carry it; the surface itself arrives with the work that needs it.
+- Giving Transformer a twins surface. Twins search consumes the DASH CNN's penultimate activation as its query embedding, so this would require a compatible Transformer embedding — separate work.
+- Making the registry data-driven or self-registering. Definitions stay code-native.
+- The build and deployment path for an image containing an unpublished model, including image tagging and registry credentials.
+- Per-visitor identity, audit logging, and rate limiting on gated models. The credential is shared by design, because the intended visitor is anonymous.
+- Suppressing institutional attribution for a double-blind visitor. Whether a deployment's branding is compatible with a given review policy is settled with the authors and the journal, not in the application.
+
+### Dependencies / Assumptions
+
+- The registry remains code-native, so listing, access policy, redshift policy, and surface list are all declared in Python definitions and changed by deploying.
+- Twins remains reachable only after a DASH classification, because it depends on that model's embedding.
+- REST API write endpoints remain disabled by default (`app/astrodash/views.py:34-36`), so R25 constrains a path that is currently unreachable for every model and becomes load-bearing when writes are enabled.
+- A single shared credential is assumed acceptable to whoever distributes the link. If a per-visitor credential were required, R8 and R10 would change shape.
+- The existing model-selection and classify flows keep carrying the chosen model in the session, so a scoped session is an extension of a mechanism that already exists rather than a replacement for it.
+- An OIDC integration and Django's auth framework are already wired (`app/astrodash_project/settings.py:89`, `:159`, `:226`; `app/astrodash_project/urls.py:16`; `app/users/urls.py:5`) but protect no AstroDash view today. The shared-credential session is independent of the authenticated user: being logged in neither grants nor bypasses gated-model access.
+
+<!-- ce-section: work-relationships -->
+### How This Work Fits Together
+
+This plan owns the generic registry capability. The breakdown below is the current understanding of the surrounding work, not a committed roadmap; later plans may revise, split, merge, or discard it.
+
+- Integrating a specific unreleased classifier
+  - Depends on this plan for listing control, the access gate, redshift-input policy, and the surface list.
+  - Still to decide: the build and deployment path for an image carrying an unpublished model, and how its commits are kept private until publication.
+- A Reconstruction result surface
+  - Depends on this plan's surface registry.
+  - Can proceed independently of the classifier integration once the surface mechanism exists.
+- Identity and access management for the REST API
+  - Shares the access question with R9. Whichever lands second inherits the other's decision about gated models and the API.
+
+### Sources / Research
+
+- `app/astrodash/infrastructure/ml/model_registry/_model_definition.py:53-68` — the current definition field list; `:17-18` and `:71-73` — the two lifecycle status values and `is_active`.
+- `app/astrodash/infrastructure/ml/model_registry/__init__.py:52-55` — the `MODELS` roster; `:68-77` and `:125` — import-time invariants, including exactly one active default; `:17-19` — the code-native intent.
+- `app/astrodash/ui_views.py:186` — active definitions drive selection cards; `:357` and `:389` — the model is written to and read from the session; `:395-396` — classify redirects to selection when the session has no model; `:657` — the sole functional read of `supports_twins`; `:767` and `:771-772` — the batch flow reads the same session key.
+- `app/astrodash/forms.py:15` — choice lists derive from active definitions; `:80` and `:107` — redshift is optional at the field level and required only by validation; `:296` — batch takes its model from the session.
+- `app/astrodash/ui_views.py:792` — a second redshift validation gate in the batch flow, distinct from the classification form's check and governed by R14.
+- `app/astrodash/templates/astrodash/classify.html:30`, `:114`, `:273` — the three hardcoded per-model template gates; `:91` and `:94` — redshift controls render unconditionally.
+- `app/astrodash/views.py:65-103` — API model resolution rejects inactive models; `:34-36` and `:194` — API writes are disabled by default.
+- `app/astrodash/tests/test_no_model_type_literals.py:37-42` — the guard test's file list, which excludes templates and `views.py`.
+- `app/astrodash/urls.py:15-17` — twins supporting routes are separate from the classify route.
+- `docs/guides/contributing-classifiers.md` — the documented steps for adding a classifier, which this capability extends.
+- `STRATEGY.md` — the "Model library & curation" track, which this capability serves.
+- `app/astrodash/views.py:34-49` — `api_writes_required`, the only hand-rolled gate decorator in the codebase and the shape KTD1 mirrors.
+- `app/astrodash/core/middleware.py` — FastAPI/Starlette middleware, unreferenced by Django's `MIDDLEWARE`. Not a usable precedent; there is no project-authored Django middleware.
+- `app/astrodash/tests/test_model_registry.py:66-73` — the registry fixture idiom (`dataclasses.replace` plus a patched roster) that KTD9 adopts.
+- `app/astrodash/templates/astrodash/classify.html:50-61` — the only conditional form-field render in the codebase, and the precedent KTD6 follows.
+- Django 5.2 signing (`docs.djangoproject.com/en/5.2/topics/signing/`) — `Signer`/`TimestampSigner` became keyword-only in 5.1, and `SignatureExpired` subclasses `BadSignature`.
+- Django 5.2 sessions (`docs.djangoproject.com/en/5.2/topics/http/sessions/`) — `set_expiry` has no ceiling helper, and `flush()` only revokes server-side on a non-cookie backend.
+
+---
+
+## Planning Contract
+
+### Key Technical Decisions
+
+- KTD1. Gate with a view decorator, not middleware. The codebase has exactly one hand-rolled gate — the interim API-writes decorator — and no project-authored Django middleware at all; Django's own guidance reserves middleware for whole-app defaults. Governs R9.
+- KTD2. The entry link is a Django signed token carrying the model id and an absolute expiry stamped at mint (session-settled: user-approved — chosen over a bare query parameter, a signed link used as the sole credential, and ingress auth: it keeps the credential convention editors already use while adding expiry). Absolute rather than evaluated against current configuration, so shortening the window cannot retroactively move an outstanding link's deadline. Governs R5, R6, R7, R8, R10, R28.
+- KTD3. The scope carries its own absolute deadline in the session payload, and the gate checks it on every guarded request. Django's `set_expiry` treats an integer as *seconds of inactivity* and re-arms on each session write, so a clamp alone bounds idleness rather than lifetime — and the classify flow writes on every submit. `set_expiry` stays as a secondary bound only. Governs R28.
+- KTD4. Gate configuration is a validator over the roster, invoked from the app config's `ready()` hook, not from registry import. An import-time check is lazy — `migrate` and `collectstatic` never reach it — so a misconfigured deployment would start and fail on first request instead. `ready()` runs for the server and every management command, so the init container fails first. Accepted consequence: the validator iterates the roster, which imports the classifier modules and transitively torch, so those two commands now load it eagerly where they did not before. U1 verifies both still complete in the init container. Governs R10, R34.
+- KTD5. The tab strip renders from the *selected* model; a supporting route authorizes from the *classified* model only when it consumes a classification artifact, and from the selected model otherwise (session-settled: user-approved — chosen over adding a boolean per surface, and over adding a model parameter to the twins routes: those routes carry no model today). The distinction is load-bearing: the twins tab and its pane appear on a DASH-selected page before any classification, and the twins page and data routes serve a model-agnostic payload, so authorizing those from the classified model would refuse a surface that works today. Only the twins search route reads a classification artifact. Governs R16, R17, R18, R19, R20, R30, R31.
+- KTD6. A model that declines redshift omits the controls in the template; the form field stays declared. No form in this codebase has ever removed a field, and the only conditional-render precedent wraps the field group. Governs R14.
+- KTD7. Listing is a new field on the definition, not a widening of lifecycle status. Widening status would silently inherit every existing active-model gate, including the one-active-default invariant. Governs R1.
+- KTD8. Teardown owns three key categories — the scope keys, the selection keys, and every session key under the classification-artifact prefix — and never calls `flush()`. All three are named because both redemption and explicit end call the same helper, and a definition covering only scope and artifacts would leave a prior selection standing, which is how a scope ends up running a model it does not name. Flushing is excluded because the session is shared with Django auth, so it would log out an authenticated visitor. Governs R29, R33.
+- KTD9. Tests build gated fixtures with `dataclasses.replace` on a real definition plus a patched roster — the established idiom. Such a fixture never passes through the import-time validators, so invariant and configuration scenarios call the validators directly rather than reloading modules. Governs R32.
+- KTD10. The effective model — scope first, then session selection — is passed into the classification form, which derives both its choices and its redshift policy from it. Without this the units collide: repointing choices at listed models makes a gated model's id an invalid choice, so a scoped submission fails validation before the view consults the scope. A selection the registry cannot resolve — a user-uploaded model — falls back to the Classification surface alone and to today's optional-redshift behavior, so the new policies never strand the path R23 protects. Governs R11, R12, R13.
+- KTD11. The surface id-to-presentation map lives in the web layer; the model definition declares opaque ids only, and the registry validates them against a known-id set passed in. Nothing under the ML infrastructure package imports Django or reads the environment today, and route names are web-layer knowledge. The template-overlay, RLAP, and redshift-estimation capability flags stay per-model booleans outside the surface list — they gate content within a surface rather than being surfaces. Governs R16, R30.
+- KTD12. A field being replaced stays as a derived read-only property until the unit that owns its read sites migrates them, and is deleted there. The redshift boolean and the twins boolean each have read sites outside the units that introduce their replacements, so removing them at introduction would break classification between units. Governs R14, R31.
+
+### High-Level Technical Design
+
+The scoped session's lifecycle is the part most likely to be built inconsistently, because four separate triggers end it:
+
+```mermaid
+stateDiagram-v2
+  [*] --> Unscoped
+  Unscoped --> Prompted: valid link opened
+  Unscoped --> Refused: link expired or malformed
+  Prompted --> Prompted: wrong credential, link still valid
+  Prompted --> Scoped: credential accepted
+  Prompted --> Refused: link expired between prompt and submit
+  Scoped --> Refused: deadline passed, detected on next guarded request
+  Scoped --> Unscoped: ended explicitly
+  Scoped --> Unscoped: model published, scope dissolves
+  Refused --> [*]
+  Unscoped --> [*]
+```
+
+Three of the four exits run teardown at request time. The fourth — an abandoned session that simply lapses — runs no code at all, which is why R33 is scoped to reachability and why every artifact it covers must live in the session and nowhere else. A logout also destroys the scope without entering teardown; that is acceptable because it destroys the artifacts with it.
+
+Gate checks run in a fixed order on a guarded request, because the order determines what a refused visitor learns: **deadline → scope present → model selectable → surface declared**.
+
+Splitting one accessor into three means each existing caller must be repointed deliberately:
+
+| Consumer | Reads today | Reads after |
+|---|---|---|
+| Selection-page cards | active definitions | listed definitions |
+| Form choice lists | active definitions | listed definitions |
+| REST API acceptance | active definitions | active, minus gated |
+| Model resolution by id | registry lookup | unchanged — listing is not protection |
+
+Surface rendering derives from the declared list rather than per-model conditionals:
+
+```mermaid
+flowchart TB
+  D[Model definition declares ordered surface ids] --> V[Registry validates ids against the known set]
+  W[Web-layer surface map resolves id to title, pane, routes] --> T[Tab strip renders from the selected model]
+  W --> G[Supporting-route guard authorizes from the classified model]
+  G --> A[Serve]
+  G --> R[Refuse]
+```
+
+### Assumptions
+
+- A scope does not survive Django logout, which flushes the session. It *does* survive login, which cycles the session key while retaining the data — so the scope and its deadline carry into the authenticated session. Both directions are pinned by tests rather than assumed.
+- Redeeming an entry link replaces any existing selection and its artifacts before writing scope keys, and only one scope exists at a time.
+- An entry link opened after its model has been published redirects into the normal public flow rather than refusing, so a reviewer is never locked out of a model that is now public.
+- A scoped visitor who requests the selection or batch page is refused and offered the explicit end action; navigating away is not treated as an implicit end.
+- One shared credential covers every simultaneously gated model, and rotating it requires a pod restart. Acceptable at this shape; it would not be if several models were under review at once with different audiences.
+- R33 covers session-held artifacts. Request profiler records and application logs are outside it, which is why the profiler must stay off in an environment serving a gated model.
+- Four new deployment values are needed in `../astrodash-k8s-gitops` before any environment can serve a gated model: the expiry window and link host as configmap keys, and the shared credential and signing key as per-cluster sealed secrets. The shipped roster contains no gated model, so an app image landing before the chart change cannot fail closed on startup.
+
+### Sequencing
+
+U1 and U2 are the registry foundation and are independent of each other; either can land first. U3, U4, and U5 consume them and are independent of one another. U6, U7, and U9 are the gate, in that order — U9 needs the scope machinery U7 establishes. U8 closes the guardrails and documentation and depends on the shape of everything before it.
+
+Per KTD12, no unit deletes a field whose read sites belong to a later unit; the replaced field survives as a derived property until its consuming unit removes it. This is what keeps each unit independently shippable rather than leaving a broken intermediate state.
+
+---
+
+## Implementation Units
+
+### U1. Registry fields for listing, access, and redshift policy
+
+- **Goal:** the model definition can express listing, credential requirement, and a three-way redshift input policy, with invariants that make illegal combinations impossible.
+- **Requirements:** R1, R4, R5, R13, R15, R26, R34
+- **Dependencies:** none
+- **Files:**
+  - Modify: `app/astrodash/infrastructure/ml/model_registry/_model_definition.py`
+  - Modify: `app/astrodash/infrastructure/ml/model_registry/__init__.py`
+  - Modify: `app/astrodash/infrastructure/ml/model_registry/definitions/dash.py`
+  - Modify: `app/astrodash/infrastructure/ml/model_registry/definitions/transformer.py`
+  - Create: `app/astrodash/core/gate_config.py`
+  - Modify: `app/astrodash/apps.py`
+  - Test: `app/astrodash/tests/test_model_registry.py`
+- **Approach:**
+  1. Add a `listed` boolean, a credential-requirement declaration, and a three-way redshift input policy to the definition dataclass. Keep `requires_redshift` as a derived read-only property over the new policy per KTD12 — U4 owns its read sites and deletes it there.
+  2. Add a `listed_definitions()` accessor beside `active_definitions()`; listing and activity stay separate questions per KTD7.
+  3. Extend `validate_registry` with the R26 invariants — gated implies unlisted, and the active default must be listed and ungated — beside the existing duplicate-id and one-active-default checks.
+  4. Put the credential, window, and signing-key reads in one small configuration module that U6 later imports, so the startup check and the gate cannot drift apart on names or defaults.
+  5. Add the gate-configuration validator as a function over the roster and the configuration, and call it from the app config's `ready()` hook per KTD4. Treat empty and whitespace-only values, and a signing key left at its committed default, as unconfigured.
+  6. Set DASH and Transformer to listed, ungated, with redshift policies matching today's behavior.
+- **Patterns to follow:** `validate_registry`'s pure-argument signature and raise-on-violation style; the existing `AppConfig.ready()` hook.
+- **Test scenarios:**
+  - A definition declaring a credential requirement while listed is rejected by the validator.
+  - A definition declaring a credential requirement while being the default is rejected by the validator.
+  - An unlisted definition marked as the active default is rejected by the validator.
+  - A gated definition with no configured credential is rejected, naming the missing configuration. `Covers AE13.`
+  - A gated definition whose credential is an empty or whitespace-only string is rejected.
+  - A gated definition with the signing key left at its committed default is rejected.
+  - A roster with no gated model passes with the gate configuration entirely absent.
+  - `listed_definitions()` excludes an unlisted-but-active model while `active_definitions()` still includes it.
+  - A retired model remains excluded from both, preserving today's behavior.
+  - DASH and Transformer resolve with the same redshift semantics they have today, through the derived property.
+- **Verification:** the validators are callable directly against a constructed roster, the existing retirement and invariant tests pass unchanged, classification still works with the derived redshift property in place, and both `migrate` and `collectstatic` complete in the init container now that the ready hook imports the roster eagerly.
+
+### U2. Surface registry and declared surface lists
+
+- **Goal:** result surfaces become a declared, ordered list resolved through a registry, replacing the per-model twins boolean.
+- **Requirements:** R16, R17, R18, R30, R31
+- **Dependencies:** none
+- **Files:**
+  - Create: `app/astrodash/surfaces.py`
+  - Modify: `app/astrodash/apps.py`
+  - Modify: `app/astrodash/infrastructure/ml/model_registry/_model_definition.py`
+  - Modify: `app/astrodash/infrastructure/ml/model_registry/__init__.py`
+  - Modify: `app/astrodash/infrastructure/ml/model_registry/definitions/dash.py`
+  - Modify: `app/astrodash/infrastructure/ml/model_registry/definitions/transformer.py`
+  - Test: `app/astrodash/tests/test_model_registry.py`
+- **Approach:**
+  1. Define the surface map in the web layer per KTD11 — id to display title, pane identity, and the supporting routes the surface owns. The ML package keeps importing no Django.
+  2. Add an ordered surface-id tuple to the definition. Keep `supports_twins` as a derived read-only property over that tuple per KTD12; U5 owns its single read site and deletes it there.
+  3. Validate that every declared id is in the known-id set passed to the validator, that the list is non-empty, and that it includes the classification surface. Invoke this from the app config's `ready()` hook with the web-layer id set, per KTD4 — the import-time call cannot see it without breaking the layer boundary, and without a runtime caller a bad id would surface as a broken tab instead of a refused startup.
+  4. Declare Classification plus DASH Twins for DASH, Classification only for Transformer — today's behavior exactly.
+  5. Keep the template-overlay, RLAP, and redshift-estimation flags as booleans outside the list, per R30.
+- **Patterns to follow:** `validate_registry`'s pure-argument signature and the ordered-tuple roster convention.
+- **Test scenarios:**
+  - A definition declaring an unknown surface id is rejected by the validator.
+  - A definition declaring an empty surface list is rejected.
+  - A definition omitting the classification surface is rejected.
+  - DASH resolves Classification then DASH Twins in that order; Transformer resolves Classification alone. `Covers AE7.`
+  - The derived twins property agrees with the declared list for both models.
+  - The three remaining capability booleans still resolve independently of the surface list.
+- **Verification:** the surface map resolves every id both definitions declare, and classification still works with the derived twins property in place.
+
+### U3. Split listing from choice lists and API acceptance
+
+- **Goal:** an unlisted model disappears from every surface an ordinary visitor can reach, while staying resolvable, and the API refuses gated models.
+- **Requirements:** R2, R3, R25, R27
+- **Dependencies:** U1
+- **Files:**
+  - Modify: `app/astrodash/forms.py`
+  - Modify: `app/astrodash/ui_views.py`
+  - Modify: `app/astrodash/views.py`
+  - Test: `app/astrodash/tests/test_api_model_type.py`
+  - Test: `app/astrodash/tests/test_classifier_parity.py`
+- **Approach:**
+  1. Point the built-in choice builders and the selection-page card list at listed definitions rather than active ones.
+  2. Add the gated-model refusal to API model resolution, keeping the existing inactive-model refusal intact.
+  3. Leave an unlisted-but-ungated model resolvable by id, per R27 — listing is presentation, not protection.
+  4. Make the selection POST refuse an unlisted model, so choice validation and the card list agree.
+- **Patterns to follow:** the existing choice-builder helpers and the API's resolve-then-refuse structure.
+- **Test scenarios:**
+  - An unlisted model renders no card for the classify action and none for the batch action. `Covers AE1.`
+  - An unlisted model is absent from the classification form's choices.
+  - A hand-crafted selection POST naming an unlisted model is refused.
+  - The API refuses a gated model with API writes enabled. `Covers AE9.`
+  - The API's gated rejection is identical in status and body to its unknown-model rejection, while the retired-model rejection stays distinct. `Covers AE9.`
+  - The API still refuses a retired model and still accepts a listed active one.
+  - An unlisted, ungated model remains resolvable through the API.
+- **Verification:** the API model-type and classifier-parity modules pass, including their existing cases unchanged.
+
+### U4. Redshift input policy across both flows
+
+- **Goal:** a model that does not take redshift renders no redshift controls and validates without them, in classification and batch alike.
+- **Requirements:** R13, R14, R15
+- **Dependencies:** U1
+- **Files:**
+  - Modify: `app/astrodash/forms.py`
+  - Modify: `app/astrodash/ui_views.py`
+  - Modify: `app/astrodash/templates/astrodash/classify.html`
+  - Modify: `app/astrodash/templates/astrodash/batch.html`
+  - Modify: `app/astrodash/infrastructure/ml/model_registry/_model_definition.py`
+  - Test: `app/astrodash/tests/test_classifier_parity.py`
+  - Test: `app/astrodash/tests/test_model_registry.py`
+- **Approach:**
+  1. Replace the boolean redshift check in form validation with the three-way policy, and drop the hardcoded model name from the error message.
+  2. Apply the same policy at the batch flow's separate redshift gate, which today reads the old boolean independently.
+  3. Wrap the redshift field and the Known Redshift checkbox in a policy conditional in both templates, per KTD6.
+  4. Pass the active model's policy into both template contexts.
+  5. Delete the derived redshift property U1 left in place, following the pattern U5 applies to the twins property, and repoint the registry assertions that read it.
+  6. A selection the registry cannot resolve keeps today's optional-redshift behavior, per KTD10.
+- **Execution note:** the batch gate is a second consumer the requirements originally missed; add a failing test for it before changing the form, so the two paths are proven separately.
+- **Patterns to follow:** the existing conditional form-group swap in the classification template.
+- **Test scenarios:**
+  - A model declaring redshift not-an-input renders neither control in the classification form. `Covers AE4.`
+  - The same model renders neither control in the batch form.
+  - A submission omitting redshift validates for that model in the classification flow.
+  - A submission omitting redshift validates for that model in the batch flow.
+  - Transformer still rejects a submission with no redshift, with a message that names no model literally.
+  - DASH still accepts a submission with no redshift.
+  - A user-uploaded selection still renders both redshift controls and validates exactly as today.
+  - A model that declines redshift as input still produces a redshift estimate. `Covers AE5.`
+- **Verification:** both flows agree on the policy for the same model, and existing DASH and Transformer behavior is unchanged.
+
+### U5. Render result surfaces from the declared list
+
+- **Goal:** the tab strip, panes, and supporting-route guards derive from the declared surface list, with no per-model conditional left in the template.
+- **Requirements:** R17, R19, R20, R21
+- **Dependencies:** U2
+- **Files:**
+  - Modify: `app/astrodash/templates/astrodash/classify.html`
+  - Modify: `app/astrodash/ui_views.py`
+  - Modify: `app/astrodash/infrastructure/ml/model_registry/_model_definition.py`
+  - Test: `app/astrodash/tests/test_classifier_parity.py`
+  - Test: `app/astrodash/tests/test_model_registry.py`
+- **Approach:**
+  1. Replace the three hardcoded per-model conditionals with a loop over the **selected** model's declared surfaces per KTD5, preserving the existing tab and pane identifier convention so the Bootstrap wiring keeps working. Rendering from the classified model instead would hide the twins tab until after a classification, which today's page does not do.
+  2. Gate the twins embedding write on the **classified** model declaring the twins surface, then delete the derived twins property U2 left in place.
+  3. Add the supporting-route guard per KTD5: the twins search route authorizes from the classified model, because it is the only one reading a classification artifact; the twins page and data routes authorize from the selected model's declared surfaces, preserving today's pre-classification browsing.
+  4. Keep the first declared surface active by default.
+  5. A selection the registry cannot resolve — a user-uploaded model — falls back to the Classification surface alone, per KTD10.
+- **Patterns to follow:** the registry-driven card loop on the selection page — the only existing registry-driven rendering loop.
+- **Test scenarios:**
+  - A DASH-selected page renders both tabs in declared order with Classification active, before any classification has run. `Covers AE7.`
+  - Transformer renders only the Classification tab and no twins tab.
+  - A twins supporting route requested in a session whose last classification was Transformer is refused. `Covers AE6.`
+  - The same route in a session whose last classification was DASH is served.
+  - A DASH-selected session with no classification yet still reaches the twins page and data routes, exactly as today.
+  - A user-uploaded selection renders the Classification tab and no twins tab.
+  - The twins embedding is stored for DASH and not for Transformer.
+  - No per-model literal remains in the classification template.
+- **Verification:** the twins panel still works end to end for DASH, the tab strip matches today's pre-classification behavior, and no reference to the derived twins property remains in the tree.
+
+### U6. Entry link, credential prompt, and scoped session
+
+- **Goal:** a gated model is reachable only by redeeming an unexpired entry link and presenting the shared credential, which establishes a session scoped to that model.
+- **Requirements:** R6, R7, R8, R10, R28, R34
+- **Dependencies:** U1
+- **Files:**
+  - Create: `app/astrodash/core/model_access.py`
+  - Create: `app/astrodash/templates/astrodash/model_gate.html`
+  - Create: `app/astrodash/templates/astrodash/model_gate_refused.html`
+  - Create: `app/astrodash/management/commands/mint_model_link.py`
+  - Modify: `app/astrodash/urls.py`
+  - Modify: `app/astrodash/ui_views.py`
+  - Modify: `app/astrodash_project/settings.py`
+  - Test: `app/astrodash/tests/test_model_access.py`
+- **Approach:**
+  1. Add mint and redeem helpers over Django's signing, importing the configuration module U1 created. Use a salt distinct to this purpose and stamp an absolute deadline at mint per KTD2. Catch the expired-signature case before the bad-signature case, since the former subclasses the latter.
+  2. Add the entry route — the first UI route in the project to carry an identifier — and a credential prompt view.
+  3. Compare the submitted credential in constant time. On success, clear any prior selection and artifacts via the teardown helper, then write the scope keys including the link's absolute deadline per KTD3, with `set_expiry` as a secondary bound only.
+  4. Re-check the deadline on submit, so a link that lapses between prompt and submit is refused.
+  5. Redirect into the normal public flow when the link's model is no longer gated.
+  6. Add the mint management command — the operator's only way to produce a link. No route mints one. Take the host from configuration rather than inferring it, since the app sits behind a proxy.
+  7. Set the session cookie's secure flag alongside the CSRF cookie's, which is already set; the session now carries authorization, not just a preference.
+  8. Add the refusal template and render it for both refusal transitions — an expired or malformed link, and a link that lapses between prompt and submit. Copy is disclosure-minimal and names no model; this is the first thing an anonymous reviewer may ever see, so it cannot be a default error page.
+- **Patterns to follow:** the module-level configuration read and `functools.wraps` shape of the existing interim API gate.
+- **Test scenarios:**
+  - An unexpired link renders the credential prompt.
+  - An expired link renders the refusal template, names no model, and is not a default error page. `Covers AE2.`
+  - A tampered token is refused and is indistinguishable from the expired case at the view level.
+  - A correct credential establishes a scope naming exactly that model.
+  - An incorrect credential on a valid link redisplays the prompt and permits another attempt. `Covers AE11.`
+  - A session write after grant does not move the stored deadline.
+  - A link that expires between prompt render and credential submit is refused.
+  - A link whose model has since been published redirects into the public flow.
+  - Redeeming clears a prior selection and its artifacts before the scope is written.
+  - The mint command produces a redeemable link; no URL route mints one.
+- **Verification:** a scoped session exists only after a correct credential on an unexpired link, its stored deadline is immovable, and every refusal path renders the refusal template rather than a framework default.
+
+### U7. Enforce the scope across surfaces
+
+- **Goal:** every surface that can run a gated model consults the scope, and a scoped visitor is locked to one model.
+- **Requirements:** R9, R11, R12
+- **Dependencies:** U5, U6
+- **Files:**
+  - Modify: `app/astrodash/core/model_access.py`
+  - Modify: `app/astrodash/ui_views.py`
+  - Modify: `app/astrodash/forms.py`
+  - Modify: `app/astrodash/templates/astrodash/classify.html`
+  - Test: `app/astrodash/tests/test_model_access.py`
+- **Approach:**
+  1. Add the gate decorator per KTD1 and apply it to the classification view and every declared surface's supporting routes, evaluating checks in the order the design section fixes.
+  2. Pass the effective model into the classification form per KTD10, so its choices and redshift policy both follow the model that will actually run.
+  3. Render the model control disabled and named in a scoped session, reusing the hidden-input-plus-plaintext substitution the template already uses for user-uploaded models.
+  4. Take the model from the scope rather than the submitted field inside a scoped flow. The classify view already ignores the form's model field for execution, so this pins existing behavior rather than adding new enforcement.
+  5. Check the stored deadline on every guarded request — U6 stamps and stores it, this unit is where it is enforced and therefore where the regression test lives.
+- **Execution note:** start from a failing test that classifies repeatedly and then asserts the deadline still holds. An idle-timeout implementation passes a naive expiry test and fails this one, which is exactly the defect to guard against.
+- **Patterns to follow:** the `functools.wraps` decorator shape from the interim API-writes gate, reusing U6's decorator rather than a second one; the conditional model-control substitution already in the classification template.
+- **Test scenarios:**
+  - A gated model's classification view is refused without a scope.
+  - Each declared surface's supporting routes are refused without a scope.
+  - A scoped session renders the model control disabled and showing that model.
+  - A scoped submission whose model id is not in the listed choice set still validates and runs.
+  - An altered request inside a scoped flow still runs the scoped model. `Covers AE3.`
+  - A session holding a user-uploaded selection, after redeem, runs the scoped model rather than the uploaded one. `Covers AE15.`
+  - A session that keeps classifying still loses access at the link's deadline. `Covers AE10.`
+  - A scope survives Django login with its deadline intact.
+- **Verification:** no route that can run a gated model is reachable without a live scope, and the model that executes is always the scoped one.
+
+### U9. Scope boundaries and teardown
+
+- **Goal:** a scope has exactly one way out of each state, ending it discards what it produced, and a session whose model stopped being selectable is turned away.
+- **Requirements:** R24, R29, R33, R35
+- **Dependencies:** U7
+- **Files:**
+  - Modify: `app/astrodash/core/model_access.py`
+  - Modify: `app/astrodash/ui_views.py`
+  - Modify: `app/astrodash/urls.py`
+  - Modify: `app/astrodash/templates/astrodash/classify.html`
+  - Test: `app/astrodash/tests/test_model_access.py`
+- **Approach:**
+  1. Add one teardown helper that owns the scope keys and every session key under the classification-artifact prefix, per KTD8. Never `flush()` — the session is shared with Django auth.
+  2. Refuse the batch flow and the selection page for a scoped session, covering the selection POST as well as the rendered page, and surface the explicit end action on the refusal.
+  3. Add the explicit end action as a POST route that runs the teardown helper and is idempotent when unscoped.
+  4. Revalidate the session's model on entry to the classification and batch flows; dissolve a scope whose model has been published, and return a public session whose model became gated or unlisted to the selection page. Revalidation applies only to ids the registry resolves — a user-uploaded selection passes through untouched, or every uploaded-model visitor gets bounced to the picker.
+  5. Reuse the same teardown helper at redeem, so a prior selection and its artifacts are cleared before scope keys are written.
+  6. Render a persistent end-session control on the classification page beside the disabled model control. Surfacing it only on a refusal means a reviewer who never leaves classification never finds it.
+  7. Give the deadline-lapse refusal its own copy — naming that the review window ended and pointing back to whoever sent the link — while the cold-link refusal keeps the disclosure-minimal wording. The two have different audiences: one already knows the model, the other must not learn it exists.
+- **Patterns to follow:** the `messages.error` plus redirect refusal idiom already used throughout the UI views; the `classify_`-prefixed session-key convention as the artifact namespace.
+- **Test scenarios:**
+  - The batch flow is refused for a scoped session and the refusal surfaces the end action. `Covers AE8.`
+  - The selection page and its POST handler are both refused for a scoped session.
+  - Ending the scope clears it and discards the stored embedding, so a later twins request is refused. `Covers AE12.`
+  - After teardown no session key under the artifact prefix survives, and no selection key survives either.
+  - Teardown leaves an authenticated visitor still logged in.
+  - The end-session control renders on every guarded page load, not only after a refused navigation.
+  - A user-uploaded session passes revalidation unchanged and reaches both the classification and batch flows.
+  - A lapsed scope's refusal tells the visitor the window ended; a cold-link refusal does not.
+  - The end action is idempotent when no scope exists.
+  - A public session whose model became gated is returned to selection on entry. `Covers AE14.`
+  - A scope whose model has been published dissolves on the next request.
+  - A scope whose deadline has passed refuses further classification and names no model, even if the session was written to since it was granted.
+  - Logout leaves no scope and no artifact key behind.
+- **Verification:** no artifact of a gated classification remains reachable after any exit from the scope, and no exit path logs out an authenticated visitor.
+
+### U8. Extend the literal guard and rewrite the contributor guide
+
+- **Goal:** a per-model conditional cannot be reintroduced unnoticed, and the contributor documentation describes the surface the registry now owns.
+- **Requirements:** R22, R23, R32
+- **Dependencies:** U3, U4, U5, U9
+- **Files:**
+  - Modify: `app/astrodash/tests/test_no_model_type_literals.py`
+  - Create: `app/astrodash/tests/gate_fixtures.py`
+  - Test: `app/astrodash/tests/test_model_access.py`
+  - Modify: `docs/guides/contributing-classifiers.md`
+  - Modify: `docs/admin/` operator documentation for minting and distributing a review link
+- **Approach:**
+  1. Extend the guard's scanned-file list to cover the classification and batch templates and the access module, and add template-comment handling so the scan does not trip on commented markup.
+  2. Add a guard that walks the surface map's declared routes plus the classification route, resolves each, and asserts the gate is applied — this is what turns the "a surface added later cannot silently omit the check" intent into a property the suite enforces, since a decorator is opt-in by nature.
+  3. Add a guard that views reachable in a scoped flow write no session key outside the artifact prefix and the enumerated scope and selection keys. The teardown sweep already covers anything added under the prefix; the escape route is an artifact stored outside it, where the sweep will never reach. A guard shaped the other way round would fail immediately against the classification view's own prefixed writes.
+  4. Consolidate the ad hoc gated fixtures U6, U7, and U9 each built locally into one shared module, per KTD9.
+  5. Rewrite the contributor guide's registration section around listing, access policy, redshift policy, and the surface list, replacing the capability-flags-as-gate-predicates framing.
+  6. Document the operator procedure: minting a link, what to hand the editor, and how publication clears the gate.
+- **Patterns to follow:** the existing guard test's positive and negative sample-line self-tests.
+- **Test scenarios:**
+  - A per-model literal reintroduced into the classification template fails the guard.
+  - A per-model literal reintroduced into the access module fails the guard.
+  - A commented-out literal in a template does not trip the guard.
+  - A surface route left without the gate fails the guard.
+  - A session write to a non-artifact-prefixed key in a scoped-flow view fails the guard.
+  - The guard's own sample-line self-tests still pass.
+  - User-uploaded models still classify unchanged. `Covers AE7.`
+- **Verification:** the full suite passes, the contributor guide describes no step the code no longer requires, and an operator can mint and distribute a link from the documentation alone.
+
+---
+
+## System-Wide Impact
+
+**The auth and session boundary.** One session object is shared with Django's auth framework and the installed-but-unapplied OIDC stack. The effects run both ways: logout destroys a scope, login carries one through, and teardown must therefore delete named keys rather than flushing. These scope keys are the seam the identity work later takes over — when the gate is retired per KD10, the surface map's route list is the enforcement point that survives.
+
+**Layer purity.** Nothing under the ML infrastructure package imports Django or reads the environment today. The gate configuration and the surface presentation map both stay outside it (KTD4, KTD11); the registry receives what it needs as arguments, matching how its existing validator already works.
+
+**The REST API's error contract.** One function funnels model resolution for both API entry points and gains a third refusal. The gated rejection must be textually indistinguishable from the unknown-model rejection while the retired-model message stays distinct — an observable change to the API's error contract, in a project with no API versioning mechanism. It becomes load-bearing only when API writes are enabled.
+
+**A formerly public route becomes session-dependent.** The twins data route serves a global payload today with no session dependency. Gating it breaks any direct or bookmarked consumer.
+
+**First identifier-bearing UI route.** No UI route carries a path parameter today. The credential POST interacts with the configured allowed hosts and trusted origins, and the twins pane is a same-origin iframe whose sub-request carries the session cookie.
+
+**Startup failure shape.** With the check in the app config's `ready()` hook, an unconfigured gate fails the init container's migrate step and surfaces as a crash-loop with the message in pod logs, blocking the web container from starting. That is what R34 looks like in practice.
+
+**Cross-repo.** The chart in `../astrodash-k8s-gitops` needs four values, not two: the expiry window and the link host as configmap keys, and the shared credential and the entry-link signing key as sealed-secret entries. The signing key matters because it currently falls back to a committed insecure default, which would make links forgeable. Sealed secrets are per-cluster, so DEV and PROD each need their own re-sealed values. Deploy order is safe in one direction only: the shipped roster contains no gated model, so an app image landing before the chart change cannot fail closed.
+
+---
+
+## Risks & Dependencies
+
+| Risk | Trigger | Mitigation | Owner |
+|---|---|---|---|
+| Scope outlives its link | An integer session expiry is an idle timeout, and the classify flow writes on every submit | U6 stamps and stores an absolute deadline; U7's gate checks it on every guarded request | U6, U7 |
+| Scope runs a model it does not name | A stale uploaded-model selection outranks model type in the classify path | Redeem clears selection and artifacts before writing scope keys | U6, U7 |
+| A later surface silently omits the gate | A decorator is opt-in by nature | Guard test walking the surface map's routes | U8 |
+| Entry links forgeable | Signing key left at its committed default | The startup check covers the signing key, not just the credential | U1 |
+| Gated inputs persist after a lapse | Sessions are database-backed and nothing runs Django's expired-session cleanup in either repo | R33 is scoped to reachability; row retention is a named deployment dependency | U9, gitops |
+| Scope cookie sent in plaintext | The session cookie's secure flag is unset while the CSRF cookie's is set | Set it alongside the existing one | U6 |
+| Credential or spectra captured by the profiler | The request profiler is installed and its sample rate is environment-tunable | Documented operational constraint, not a control: do not raise it in an environment serving a gated model | U8 |
+
+Dependencies: the gitops chart change above; and one shared credential covering all simultaneously gated models, rotated only by redeploy.
+
+---
+
+## Verification Contract
+
+| Gate | Command | Applies to |
+|---|---|---|
+| Full suite with coverage | `run/astrodash.test.sh slim_dev` | Every unit; required before done |
+| Single module while iterating | `docker compose <compose args> exec app_dev python manage.py test astrodash.tests.<module> -v 2` | Any unit |
+| Formatting | `black` over changed Python | Every unit touching Python |
+| Registry invariants | `astrodash.tests.test_model_registry` | U1, U2 |
+| Literal and coverage guards | `astrodash.tests.test_no_model_type_literals` | U5, U8 |
+| Gate behavior | `astrodash.tests.test_model_access` | U6, U7, U9 |
+
+Compose arguments come from `run/get_compose_args.sh <profile>`; the dev service is `app_dev`.
+
+Base-class split: registry and guard tests need no database. Gate tests **do** — no session engine is configured, so sessions are database-backed and anything exercising the credential prompt, scope establishment, or teardown through the test client hits the sessions table. The repo already splits this way, using the lighter base class where views never touch the session and the database-backed one where session state is manipulated directly.
+
+Behavioral check beyond the suite. The gated fixture lives in the test suite, which a running server never loads, so exercising the gate locally takes a recipe rather than a one-liner:
+
+1. Add a temporary gated entry to the roster locally. Do not commit it.
+2. Set the four gate values in the dev environment — credential, window, signing key, link host — or the startup validator refuses to boot.
+3. Bring up `full_dev`. Confirm DASH still renders both tabs and Transformer only one, and that the twins explorer still opens before any classification.
+4. Mint a link with the management command, then confirm the credential prompt, the scoped form, the refusal copy, and the explicit end all behave as specified.
+5. Revert the roster entry before committing.
+
+---
+
+## Definition of Done
+
+Global:
+
+- Every requirement this plan cites is satisfied or explicitly traced to the unit that satisfies it.
+- The full suite passes under `run/astrodash.test.sh slim_dev`.
+- Changed Python is formatted with `black`, and new function signatures carry type hints and Google-style docstrings.
+- DASH and Transformer behave for an ordinary visitor exactly as they do today — selection, form fields, validation messages, and available surfaces.
+- The replaced redshift and twins booleans have no remaining references, each deleted by the unit that owns its read sites.
+- No per-model literal remains in the templates the guard now scans.
+- No URL route mints an entry link; minting is operator-only.
+- Every route the surface map declares carries the gate, proven by the guard rather than by inspection.
+- Abandoned or experimental code from approaches that did not work out is removed, not left in the diff.
+- The contributor guide matches what the code actually requires.
+
+Per unit: the unit's own Verification line holds, and its test scenarios are covered by real tests rather than annotations.
+
+Not done here: any specific classifier, the Reconstruction surface, and the chart change in `../astrodash-k8s-gitops` that the new deployment values require before a gated model can be served anywhere.


### PR DESCRIPTION
## Summary

A model definition now controls its own public surface. A classifier can be
fully usable while unlisted on the selection page, reachable only through a
model-scoped entry link that expires and asks for a shared access code, and
landing the visitor in a classification form locked to that one model.
Definitions also declare whether redshift is an input at all, and which result
surfaces they offer.

Before this, `is_active` answered three unrelated questions at once - whether a
card renders, whether the model appears in form choices, and whether the REST
API accepts it - so a model was either wholly public or wholly unavailable.
That blocked the case this work exists for: a classifier whose describing paper
is under review must work for an assigned reviewer while staying un-browsable,
and that reviewer is anonymous, so nothing requiring an account will do.

This is the complete arc of one plan
(`docs/plans/2026-08-11-001-feat-registry-driven-model-surface-plan.md`, units
U1 through U9). It ships the generic capability only. Integrating any specific
classifier, and the Reconstruction result surface, are separate work that
depends on this.

## What a definition declares now

| Question | Field | Effect |
|---|---|---|
| Offered for new use? | `status` | A retired model leaves the cards but still resolves its label for stored results. |
| Advertised? | `listed` | An unlisted model renders no card and appears in no choice control. Presentation only, never protection. |
| Credential to reach it? | `requires_credential` | Reachable only by redeeming an entry link and presenting the shared code. The REST API refuses it outright. |
| Redshift an input? | `redshift_input` | Three-way: required, optional, or not an input. A model that declines it renders neither redshift control and validates without one, in both flows. |
| Which result tabs? | `surfaces` | An ordered list resolved against a surface registry. DASH declares Classification and DASH Twins; Transformer declares Classification. |

For an ordinary visitor, DASH and Transformer behave exactly as they do today -
selection, form fields, validation messages, and available surfaces. The
shipped roster contains no gated model; the gate is exercised by a test-only
fixture.

## Reaching a gated model

An operator mints a link with `manage.py mint_model_link <id>` - no route mints
one - and hands the link and the access code to whoever distributes them. The
link resolves to one model and carries a deadline stamped at mint. A correct
code establishes a session scoped to that model, which reaches the
classification flow only and expires no later than the link that created it.

## Decisions worth a reviewer's attention

- **The gate is a view decorator, not middleware.** The one hand-rolled gate
  this codebase has is the interim API-writes decorator, and there is no
  project-authored Django middleware at all. Because a decorator is opt-in, a
  guard test walks every route the surface registry declares and fails if one
  is missing the gate, bound to that route.
- **The deadline is absolute and stamped at mint.** Django's `set_expiry`
  treats an integer as seconds of *inactivity* and re-arms on every session
  write - and the classify flow writes on every submit - so it bounds idleness,
  not lifetime. The scope carries its own deadline and the gate re-checks it on
  every guarded request; `set_expiry` is kept as a secondary bound only.
- **Teardown deletes named keys and never calls `flush()`.** The session is
  shared with Django's auth framework, so flushing would log out an
  authenticated visitor along with ending the scope.
- **Result surfaces are a declared list, not a boolean per tab.** Adding a
  surface is one entry in the surface registry plus an id constant, with no
  per-model conditional in the classification template. The literal guard now
  scans that template, where three such conditionals used to hide from a
  Python-only scan.
- **The REST API refuses a gated model rather than accepting the code.** The
  refusal is textually identical to the unknown-model refusal, so the endpoint
  cannot be used to enumerate unreleased models. This is an observable change
  to the API error contract, load-bearing only once API writes are enabled.

Session-settled decisions carried from planning: the model-scoped entry link
plus shared credential (user-approved, over a bare query parameter, a signed
link as sole credential, and ingress basic auth); result surfaces as a declared
list (user-approved, over one boolean per surface); a gated session reaching
classification only (user-approved); the REST API refusing gated models
outright (user-approved); and this plan owning the generic capability only
(user-directed).

## Testing

`242 tests, all passing` (`manage.py test astrodash.tests users.tests`), up
from 160 on `main`. The gate has its own module,
`astrodash/tests/test_model_access.py`, covering link minting and expiry,
refusal disclosure, the credential prompt and its retry, scope enforcement
across every surface, teardown, and revalidation. Three guard tests were added
or extended: the model-literal scan now covers the templates and the access
module, a coverage guard asserts every declared surface route carries the gate
bound to its own route, and a sweep guard asserts a scoped flow writes no
session key outside the namespaces teardown clears.

Two fixes from code review were confirmed to fail their new tests before the
fix and pass after: an unconfigured gate rendering a framework error page
instead of the refusal page, and a scope granted without rotating the session
identifier.

Not run: the plan's manual behavioral recipe, which needs a temporary gated
roster entry and the four gate values set in a dev environment. The templates
it would exercise are rendered and asserted through the Django test client.

## Known residuals

Accepted rather than fixed here; none has live exposure with the shipped roster.

- `nginx/default.conf` and `default_slim.conf` serve
  `/astrodash/classify/twins/data/` straight from the data volume, so in the
  compose topology that route bypasses Django and its gate. The deployed
  clusters route through Traefik with no such rule, and the payload is global
  public data today.
- A lapsed scope is torn down on the visitor's next request. An abandoned
  session's row persists until something cleans it up, and nothing runs
  Django's `clearsessions` in either repo. R33 is deliberately scoped to
  reachability; row retention is a named deployment dependency.
- The shared access code has no attempt throttle and no strength floor. Rate
  limiting is an explicit Scope Boundary of the plan; the admin guide now says
  to make the code long and random.
- The model-literal guard's pattern hardcodes the two current model ids rather
  than deriving them from the roster.
- Gated result pages carry no `Cache-Control: no-store`, so the back button can
  redisplay a result after the session is ended.

## Before this can serve a gated model anywhere

The chart in `../astrodash-k8s-gitops` needs four values that do not exist yet:
the expiry window and link host as configmap keys, and the shared access code
and the entry-link signing key as per-cluster sealed secrets. The signing key
matters because `SECRET_KEY` still falls back to a committed default, which
would make links forgeable. Deploy order is safe in one direction only: the
shipped roster has no gated model, so this image landing before the chart
change cannot fail closed on startup.

## Post-Deploy Monitoring & Validation

No behavior changes for an ordinary visitor, so the validation is a
no-regression check rather than a new-feature watch.

- **Log queries:** `AstroDash starting with APP_VERSION=` at boot confirms the
  new image. `Model gate:` is the prefix for every gate log line - none should
  appear at all, since no model ships gated. `Gated models require gate
  configuration` in the init container would mean a gated model reached the
  roster without its configuration.
- **Healthy signals:** the model-selection page renders both cards; classifying
  with DASH shows the Classification and DASH Twins tabs and the twins explorer
  opens; Transformer shows Classification only and still requires a redshift;
  an uploaded model still classifies.
- **Failure signals and trigger:** a crash-looping init container (gate
  misconfiguration), 403s on `/astrodash/classify/twins/`, or session loss
  across requests (`SESSION_COOKIE_SECURE` is now on, so any environment served
  over plain HTTP on a non-localhost host loses its session). Any of these is a
  rollback trigger - redeploy the previous image tag.
- **Window and owner:** the deploying maintainer, through the first DEV
  smoke-through and the following day on PROD.

## Related

Plan: `docs/plans/2026-08-11-001-feat-registry-driven-model-surface-plan.md`
Operator guide: `docs/admin/gated-model-access.md`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
